### PR TITLE
Changes in preparation for Semantic Kernel update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+This project adheres to Azure [API Versioning](https://docs.microsoft.com/en-us/azure/api-management/api-management-versions) with [Revisions](https://docs.microsoft.com/en-us/azure/api-management/api-management-revisions) enabled.
+
+Each version and revision is followed by a date of change, specially for under development versions. Each entry provides the following information (when applicable):
+
+- **Breaking Changes**: changes that may certainty affect consumers of the API or how it is expected to be used.
+- **Major Changes**: big improvements in the code, like adding or enabling features, or bug fixes.
+- **Minor Changes**: small changes that have little impact, like spell checks in an API's documentation, adding or removing comments, etc.
+
+Also, any bug fix must start with the prefix «Bug fix:» followed by the description of the changes _per se_.
+
+Previous classification is not required if changes are simple or all belong to the same category.
+
+## [6.0.3.20]
+
+### **Major Changes**
+
+- Added  this `CHANGELOG.md`
+- In `Encamina.Enmarcha.SemanticKernel.Abstractions`, method `ValidateAndThrowIfErrorOccurred` is now obsolete, and will be removed in a future version of this library.
+- In `Encamina.Enmarcha.SemanticKernel.Plugins.Chat`, property `ChatRequestSettings` is now obsolete due to future changes in Semantic Kernel library its type `ChatRequestSettings` will change to `OpenAIRequestSettings `. Therefore, the signature of this property will change in future versions of this library.
+- In `Encamina.Enmarcha.SemanticKernel.Connectors.Memory`, the constructor of `MemoryQueryPlugin` is now obsolete due to future changes in Semantic Kernel library, where the semantic memory will be a dependency outside the `IKernel`. The `IKernel` dependency will be replaced with `ISemanticTextMemory`. The signature of this constructor will change in future versions of this library. 
+- In `Encamina.Enmarcha.SemanticKernel.Connectors.Memory`, the extension method `ImportMemoryPlugin` is now obsolete due to future changes in Semantic Kernel library, where the semantic memory will be a dependency outside the `IKernel`. An additional dependency with `ISemanticTextMemory` will be added to this extension method. The signature of this method will change in future versions of this library.
+
+## [6.0.3.18] and [6.0.3.19]
+
+- First Open Source versions of ENMARCHA.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>6.0.3.19</VersionPrefix>
+    <VersionPrefix>6.0.3.20</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/Enmarcha.sln
+++ b/Enmarcha.sln
@@ -3,12 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32421.90
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solution Items", "{B124CEEF-2F1A-4AEC-9234-CA9B08BACB11}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "[Solution Items]", "[Solution Items]", "{B124CEEF-2F1A-4AEC-9234-CA9B08BACB11}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		.runsettings = .runsettings
+		CHANGELOG.md = CHANGELOG.md
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		CONTRIBUTING.md = CONTRIBUTING.md
 		coverlet.runsettings = coverlet.runsettings

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/SKContextExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/SKContextExtensions.cs
@@ -30,6 +30,7 @@ public static class SKContextExtensions
     /// Checks if an error occurred in a Semantic Kernel context, and throws an exception if so.
     /// </summary>
     /// <param name="context">The SKContext object.</param>
+    [Obsolete(@"Due to changes in Semantic Kernel library, this method will be removed in future versions of this library. Use common exception handling techniques instead.")]
     public static void ValidateAndThrowIfErrorOccurred(this SKContext context)
     {
         if (context.ErrorOccurred)

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Plugins/ChatWithHistoryPluginOptions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Plugins/ChatWithHistoryPluginOptions.cs
@@ -20,6 +20,7 @@ public class ChatWithHistoryPluginOptions
     /// Gets a valid instance of <see cref="ChatRequestSettings"/> (from Semantic Kernel) with settings for the chat request.
     /// </summary>
     [Required]
+    [Obsolete(@"Due to future changes in Semantic Kernel library, this property type `ChatRequestSettings` will change to `OpenAIRequestSettings `. The signature of this property will change in future versions of this library.")]
     public virtual ChatRequestSettings ChatRequestSettings { get; init; } = new()
     {
         MaxTokens = 1000,

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/IKernelExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/IKernelExtensions.cs
@@ -16,6 +16,7 @@ public static class IKernelExtensions
     /// <param name="kernel">The <see cref="IKernel"/> instance to add this plugin.</param>
     /// <param name="tokensLengthFunction">A function to count how many tokens are in a string or text.</param>
     /// <returns>A list of all the functions found in this plugin, indexed by function name.</returns>
+    [Obsolete(@"Due to future changes in Semantic Kernel library, the semantic memory will be a dependency outside the `IKernel`. An additional dependency with `ISemanticTextMemory` will be added. The signature of this method will change in future versions of this library.")]
     public static IDictionary<string, ISKFunction> ImportMemoryPlugin(this IKernel kernel, Func<string, int> tokensLengthFunction)
     {
         var memoryQueryPlugin = new MemoryQueryPlugin(kernel, tokensLengthFunction);

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Plugins/MemoryQueryPlugin.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Plugins/MemoryQueryPlugin.cs
@@ -20,6 +20,7 @@ public class MemoryQueryPlugin
     /// </summary>
     /// <param name="kernel">The instance of the semantic kernel to work with in this plugin.</param>
     /// <param name="tokenLengthFunction">Function to calculate the length of a string in tokens.</param>
+    [Obsolete(@"Due to future changes in Semantic Kernel library, the semantic memory will be a dependency outside the `IKernel`. The `IKernel` dependency will be replaced with `ISemanticTextMemory`. The signature of this constructor will change in future versions of this library.")]
     public MemoryQueryPlugin(IKernel kernel, Func<string, int> tokenLengthFunction)
     {
         this.kernel = kernel;


### PR DESCRIPTION
The following changes are required to manage obsolescence and possible breaking changes on the library once Semantic Kernel references are updated to version `1.0.0`.

Issues:
- #6 