### PR TITLE
@lmarcos/issue 27# token counting functions are slow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,55 @@ Each version and revision is followed by a date of change, specially for under d
 - **Major Changes**: big improvements in the code, like adding or enabling features, or bug fixes.
 - **Minor Changes**: small changes that have little impact, like spell checks in an API's documentation, adding or removing comments, etc.
 
-Also, any bug fix must start with the prefix «Bug fix:» followed by the description of the changes _per se_.
+Also, any bug fix must start with the prefix ï¿½Bug fix:ï¿½ followed by the description of the changes _per se_.
 
 Previous classification is not required if changes are simple or all belong to the same category.
+
+## [8.0.1]
+
+### **Major Changes**
+ - In `Encamina.Enmarcha.SemanticKernel.Abstractions.ILengthFunctions`, `GptEncoding` is now cached and reused to improve performance. [(#30)](https://github.com/Encamina/enmarcha/pull/30)
+
+### Minor Changes
+  - Changes from version 8.0.0 have been added to the `CHANGELOG.md` file.
+
+## [8.0.0]
+
+### Major Changes
+
+ - Changed .NET version from 6 to 8, therefore closes issue `Everything ready for ENMARCHA 8.0.0 #7`.
+ - Updated the following .NET libraries to their newest version (8.0.0):
+   - Microsoft.AspNetCore.Authentication.JwtBearer
+   - Microsoft.AspNetCore.Authentication.OpenIdConnect
+   - Microsoft.EntityFrameworkCore
+   - Microsoft.EntityFrameworkCore.SqlServer
+   - Microsoft.Extensions.Caching.Abstractions
+   - Microsoft.Extensions.Configuration.Abstractions
+   - Microsoft.Extensions.DependencyInjection.Abstractions
+   - Microsoft.Extensions.Hosting
+   - Microsoft.Extensions.Http
+   - Microsoft.Extensions.Logging.Abstractions
+   - Microsoft.Extensions.Options
+   - Microsoft.Extensions.Options.ConfigurationExtensions
+   - Microsoft.Extensions.Options.DataAnnotations
+   - System.Net.Http.Json
+   - System.Text.Json
+ - Updated library Azure.Data.Tables from 12.8.1 to 12.8.2.
+ - Updated library Microsoft.Azure.Cosmos from 3.36.0 to 3.37.0.
+ - Updated Bot Framework related libraries from version 4.21.1 to 4.21.2. These libraries are:
+   - Microsoft.Bot.Builder.Azure
+   - Microsoft.Bot.Builder.Azure.Blobs
+   - Microsoft.Bot.Builder.Dialogs
+   - Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+   - Microsoft.Bot.Builder.Integration.AspNet.Core
+ - Updated library Moq from 4.20.69 to 4.20.70.
+ - Updated library xunit from 2.6.1 to 2.6.2.
+ - Updated library xunit.analyzers from 1.5.0 to 1.6.0.
+ - Updated library xunit.extensibility.core from 2.6.1 to 2.6.2.
+ - Updated library xunit.runner.visualstudio from 2.5.3 to 2.5.4.
+
+## Minor Changes
+ - Some minor tweaks.
 
 ## [6.0.4]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>8.0.0</VersionPrefix>
+    <VersionPrefix>8.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/ILengthFunctions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/ILengthFunctions.cs
@@ -6,14 +6,14 @@ namespace Encamina.Enmarcha.SemanticKernel.Abstractions;
 public interface ILengthFunctions : AI.Abstractions.ILengthFunctions
 {
     /// <summary>
+    /// Gets the default <see cref="GptEncoding">encoding</see> for models like `GPT-3.5-Turbo` and `GPT-4` from OpenAI.
+    /// </summary>
+    public static readonly GptEncoding DefaultGptEncoding = GptEncoding.GetEncoding("cl100k_base");
+
+    /// <summary>
     /// Dictionary to cache GptEncoding instances based on encoding names.
     /// </summary>
     private static readonly Dictionary<string, GptEncoding> EncodingCache = [];
-
-    /// <summary>
-    /// Gets the default GptEncoding for models like `GPT-3.5-Turbo` and `GPT-4` from OpenAI.
-    /// </summary>
-    private static GptEncoding defaultGptEncoding;
 
     /// <summary>
     /// Gets the number of tokens using encodings for models like `GPT-3.5-Turbo` and `GPT-4` from OpenAI on the specified text.
@@ -21,7 +21,7 @@ public interface ILengthFunctions : AI.Abstractions.ILengthFunctions
     /// </summary>
     /// <seealso href="https://platform.openai.com/tokenizer"/>
     /// <seealso href="https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb"/>
-    public static Func<string, int> LengthByTokenCount => (text) => string.IsNullOrEmpty(text) ? 0 : GetDefaultGptEncoding().Encode(text).Count;
+    public static Func<string, int> LengthByTokenCount => (text) => string.IsNullOrEmpty(text) ? 0 : DefaultGptEncoding.Encode(text).Count;
 
     /// <summary>
     /// Gets the number of tokens using a given encoding on the specified text.
@@ -29,15 +29,6 @@ public interface ILengthFunctions : AI.Abstractions.ILengthFunctions
     /// </summary>
     /// <seealso href="https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb"/>
     public static Func<string, string, int> LengthByTokenCountUsingEncoding => (encoding, text) => string.IsNullOrEmpty(text) ? 0 : GetCachedEncoding(encoding).Encode(text).Count;
-
-    /// <summary>
-    /// Gets the default GptEncoding instance, creating it if not already initialized.
-    /// </summary>
-    /// <returns>The default GptEncoding instance.</returns>
-    private static GptEncoding GetDefaultGptEncoding()
-    {
-        return defaultGptEncoding ??= GptEncoding.GetEncoding("cl100k_base");
-    }
 
     /// <summary>
     /// Gets the GptEncoding instance based on the specified encoding name, caching it for future use.

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/ILengthFunctions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/ILengthFunctions.cs
@@ -6,17 +6,53 @@ namespace Encamina.Enmarcha.SemanticKernel.Abstractions;
 public interface ILengthFunctions : AI.Abstractions.ILengthFunctions
 {
     /// <summary>
+    /// Dictionary to cache GptEncoding instances based on encoding names.
+    /// </summary>
+    private static readonly Dictionary<string, GptEncoding> EncodingCache = [];
+
+    /// <summary>
+    /// Gets the default GptEncoding for models like `GPT-3.5-Turbo` and `GPT-4` from OpenAI.
+    /// </summary>
+    private static GptEncoding defaultGptEncoding;
+
+    /// <summary>
     /// Gets the number of tokens using encodings for models like `GPT-3.5-Turbo` and `GPT-4` from OpenAI on the specified text.
     /// If the text is <see langword="null"/> or empty (i.e., <see cref="string.Empty"/>), returns zero (<c>0</c>).
     /// </summary>
     /// <seealso href="https://platform.openai.com/tokenizer"/>
     /// <seealso href="https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb"/>
-    public static Func<string, int> LengthByTokenCount => (text) => string.IsNullOrEmpty(text) ? 0 : GptEncoding.GetEncoding("cl100k_base").Encode(text).Count;
+    public static Func<string, int> LengthByTokenCount => (text) => string.IsNullOrEmpty(text) ? 0 : GetDefaultGptEncoding().Encode(text).Count;
 
     /// <summary>
     /// Gets the number of tokens using a given encoding on the specified text.
     /// If the text is <see langword="null"/> or empty (i.e., <see cref="string.Empty"/>), returns zero (<c>0</c>).
     /// </summary>
     /// <seealso href="https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb"/>
-    public static Func<string, string, int> LengthByTokenCountUsingEncoding => (encoding, text) => string.IsNullOrEmpty(text) ? 0 : GptEncoding.GetEncoding(encoding).Encode(text).Count;
+    public static Func<string, string, int> LengthByTokenCountUsingEncoding => (encoding, text) => string.IsNullOrEmpty(text) ? 0 : GetCachedEncoding(encoding).Encode(text).Count;
+
+    /// <summary>
+    /// Gets the default GptEncoding instance, creating it if not already initialized.
+    /// </summary>
+    /// <returns>The default GptEncoding instance.</returns>
+    private static GptEncoding GetDefaultGptEncoding()
+    {
+        return defaultGptEncoding ??= GptEncoding.GetEncoding("cl100k_base");
+    }
+
+    /// <summary>
+    /// Gets the GptEncoding instance based on the specified encoding name, caching it for future use.
+    /// </summary>
+    /// <param name="encoding">The name of the GptEncoding.</param>
+    /// <returns>The GptEncoding instance.</returns>
+    private static GptEncoding GetCachedEncoding(string encoding)
+    {
+        if (EncodingCache.TryGetValue(encoding, out var gptEncoding))
+        {
+            return gptEncoding;
+        }
+
+        gptEncoding = GptEncoding.GetEncoding(encoding);
+        EncodingCache[encoding] = gptEncoding;
+        return gptEncoding;
+    }
 }


### PR DESCRIPTION
- Implemented caching system to improve the performance of `GptEncoding`.
- Version updated from '8.0.0' to '8.0.1'.

Benchmark results:

```

BenchmarkDotNet v0.13.11, Windows 11 (10.0.22631.2861/23H2/2023Update/SunValley3)
AMD Ryzen Threadripper 3960X, 1 CPU, 48 logical and 24 physical cores
.NET SDK 8.0.100
  [Host] : .NET 6.0.25 (6.0.2523.51912), X64 RyuJIT AVX2
  8.0.0  : .NET 6.0.25 (6.0.2523.51912), X64 RyuJIT AVX2
  8.0.1  : .NET 6.0.25 (6.0.2523.51912), X64 RyuJIT AVX2

IterationCount=15  LaunchCount=2  WarmupCount=10  

```
| Method                                             | Job   | NuGetReferences                                     | Mean           | Error         | StdDev        |
|--------------------------------------------------- |------ |---------------------------------------------------- |---------------:|--------------:|--------------:|
| LengthByTokenCount_100Times_HelloText              | 8.0.0 | Encamina.Enmarcha.SemanticKernel.Abstractions 8.0.0 | 8,744,451.5 μs | 116,156.12 μs | 166,587.64 μs |
| LengthByTokenCountUsingEncoding_100Times_HelloText | 8.0.0 | Encamina.Enmarcha.SemanticKernel.Abstractions 8.0.0 | 4,146,039.7 μs |  92,342.23 μs | 132,434.46 μs |
| LengthByTokenCount_100Times_HelloText              | 8.0.1 | Encamina.Enmarcha.SemanticKernel.Abstractions 8.0.1 |       166.9 μs |       1.30 μs |       1.91 μs |
| LengthByTokenCountUsingEncoding_100Times_HelloText | 8.0.1 | Encamina.Enmarcha.SemanticKernel.Abstractions 8.0.1 |       135.6 μs |       1.00 μs |       1.50 μs |


Benchmark executed:
```csharp

[Config(typeof(Config))]
[MarkdownExporterAttribute.GitHub]
public class Tokenizer
{
    public class Config : ManualConfig
    {
        public Config()
        {
            var baseJob = Job.MediumRun;

            AddJob(baseJob.WithNuGet("Encamina.Enmarcha.SemanticKernel.Abstractions", "8.0.0").WithId("8.0.0"));
            AddJob(baseJob.WithNuGet("Encamina.Enmarcha.SemanticKernel.Abstractions", "8.0.1").WithId("8.0.1"));
            WithOptions(ConfigOptions.DisableOptimizationsValidator);
        }
    }

    [Benchmark]
    public void LengthByTokenCount_100Times_HelloText()
    {
        for (var i = 0; i < 100; i++)
        {
            ILengthFunctions.LengthByTokenCount("Hello");
        }
    }

    [Benchmark]
    public void LengthByTokenCountUsingEncoding_100Times_HelloText()
    {
        for (var i = 0; i < 100; i++)
        {
            ILengthFunctions.LengthByTokenCountUsingEncoding("p50k_base", "Hello");
        }
    }
}
```