### PR TITLE
Fix slow issue with ILengthFunctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Also, any bug fix must start with the prefix «Bug fix:» followed by the descript
 
 Previous classification is not required if changes are simple or all belong to the same category.
 
+## [6.0.4.1]
+
+### Major Changes
+
+- In `Encamina.Enmarcha.SemanticKernel.Abstractions.ILengthFunctions`, `GptEncoding` is now cached and reused to improve performance.
 ## [6.0.4]
 
 ### Important

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>6.0.4.0</VersionPrefix>
+    <VersionPrefix>6.0.4.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/ILengthFunctions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/ILengthFunctions.cs
@@ -13,7 +13,7 @@ public interface ILengthFunctions : AI.Abstractions.ILengthFunctions
     /// <summary>
     /// Dictionary to cache GptEncoding instances based on encoding names.
     /// </summary>
-    private static readonly Dictionary<string, GptEncoding> EncodingCache = [];
+    private static readonly Dictionary<string, GptEncoding> EncodingCache = new Dictionary<string, GptEncoding>();
 
     /// <summary>
     /// Gets the number of tokens using encodings for models like `GPT-3.5-Turbo` and `GPT-4` from OpenAI on the specified text.

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/ILengthFunctions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/ILengthFunctions.cs
@@ -6,17 +6,44 @@ namespace Encamina.Enmarcha.SemanticKernel.Abstractions;
 public interface ILengthFunctions : AI.Abstractions.ILengthFunctions
 {
     /// <summary>
+    /// Gets the default <see cref="GptEncoding">encoding</see> for models like `GPT-3.5-Turbo` and `GPT-4` from OpenAI.
+    /// </summary>
+    public static readonly GptEncoding DefaultGptEncoding = GptEncoding.GetEncoding("cl100k_base");
+
+    /// <summary>
+    /// Dictionary to cache GptEncoding instances based on encoding names.
+    /// </summary>
+    private static readonly Dictionary<string, GptEncoding> EncodingCache = [];
+
+    /// <summary>
     /// Gets the number of tokens using encodings for models like `GPT-3.5-Turbo` and `GPT-4` from OpenAI on the specified text.
     /// If the text is <see langword="null"/> or empty (i.e., <see cref="string.Empty"/>), returns zero (<c>0</c>).
     /// </summary>
     /// <seealso href="https://platform.openai.com/tokenizer"/>
     /// <seealso href="https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb"/>
-    public static Func<string, int> LengthByTokenCount => (text) => string.IsNullOrEmpty(text) ? 0 : GptEncoding.GetEncoding("cl100k_base").Encode(text).Count;
+    public static Func<string, int> LengthByTokenCount => (text) => string.IsNullOrEmpty(text) ? 0 : DefaultGptEncoding.Encode(text).Count;
 
     /// <summary>
     /// Gets the number of tokens using a given encoding on the specified text.
     /// If the text is <see langword="null"/> or empty (i.e., <see cref="string.Empty"/>), returns zero (<c>0</c>).
     /// </summary>
     /// <seealso href="https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb"/>
-    public static Func<string, string, int> LengthByTokenCountUsingEncoding => (encoding, text) => string.IsNullOrEmpty(text) ? 0 : GptEncoding.GetEncoding(encoding).Encode(text).Count;
+    public static Func<string, string, int> LengthByTokenCountUsingEncoding => (encoding, text) => string.IsNullOrEmpty(text) ? 0 : GetCachedEncoding(encoding).Encode(text).Count;
+
+    /// <summary>
+    /// Gets the GptEncoding instance based on the specified encoding name, caching it for future use.
+    /// </summary>
+    /// <param name="encoding">The name of the GptEncoding.</param>
+    /// <returns>The GptEncoding instance.</returns>
+    private static GptEncoding GetCachedEncoding(string encoding)
+    {
+        if (EncodingCache.TryGetValue(encoding, out var gptEncoding))
+        {
+            return gptEncoding;
+        }
+
+        gptEncoding = GptEncoding.GetEncoding(encoding);
+        EncodingCache[encoding] = gptEncoding;
+        return gptEncoding;
+    }
 }


### PR DESCRIPTION
Since version `6.0.4` of ENMARCHA, the token counting functions in `Encamina.Enmarcha.SemanticKernel.Abstractions.ILengthFunctions.cs` have become significantly slower. This is particularly noticeable when using them to chunk texts, as there are numerous calls to `ILengthFunctions.LengthByTokenCount`, causing a substantial slowdown in the system.

This is a pick from #30 fixed in #27.