### PR TITLE
Fix issue #34. Semantic kernel summaries plugin fails to preserve the original language of the text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ Each version and revision is followed by a date of change, specially for under d
 - **Major Changes**: big improvements in the code, like adding or enabling features, or bug fixes.
 - **Minor Changes**: small changes that have little impact, like spell checks in an API's documentation, adding or removing comments, etc.
 
-Also, any bug fix must start with the prefix «Bug fix:» followed by the description of the changes _per se_.
+Also, any bug fix must start with the prefix ï¿½Bug fix:ï¿½ followed by the description of the changes _per se_.
 
 Previous classification is not required if changes are simple or all belong to the same category.
+
+## [6.0.4.2]
+
+### **Major Changes**
+ - In `Encamina.Enmarcha.SemanticKernel.Plugins.Text` Summarize Plugin, a new parameter `locale` has been added to control the output language of the generated summary. [(#34)](https://github.com/Encamina/enmarcha/issues/34)
 
 ## [6.0.4.1]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>6.0.4.1</VersionPrefix>
+    <VersionPrefix>6.0.4.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/Summarize/config.json
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/Summarize/config.json
@@ -20,6 +20,11 @@
         "name": "maxWordsCount",
         "description": "Maximum number of words that the summary should have",
         "defaultValue": "1000"
+      },
+      {
+        "name": "locale",
+        "description": "Language in which the summary will be generated",
+        "defaultValue": "en"
       }
     ]
   }

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/Summarize/skprompt.txt
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/Summarize/skprompt.txt
@@ -1,9 +1,8 @@
-Your task is TO SUMMARIZE the INPUT text using no more than {{$maxWordsCount}} words.
-DO NOT TRANSLATE the text, USE the same language as the INPUT.
+Your task is TO SUMMARIZE the INPUT text using no more than {{$maxWordsCount}} words in the '{{$locale}}' language.
 Maximize detail and meaning.
 Focus on the content in the INPUT text.
-ALWAYS answer in the SAME LANGUAGE as the INPUT.
 USE {{$maxWordsCount}} words or less TO SUMMARIZE the content in INPUT.
+Summarize using the '{{$locale}}' language.
 
 [INPUT]
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/PluginsInfo.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/PluginsInfo.cs
@@ -71,6 +71,11 @@ public static class PluginsInfo
                     /// The name of the «minWordsCount» parameter, which represents the maximum number of words that the summary should have.
                     /// </summary>
                     public static readonly string MaxWordsCount = nameof(MaxWordsCount).ToLowerInvariant();
+
+                    /// <summary>
+                    /// The name of the «locale» parameter, which represents the language in which the summary will be generated.
+                    /// </summary>
+                    public static readonly string Locale = nameof(Locale).ToLowerInvariant();
                 }
             }
         }


### PR DESCRIPTION
This is a pick from https://github.com/Encamina/enmarcha/pull/35 fixed in https://github.com/Encamina/enmarcha/issues/34.