### PR TITLE
Improvements on ephemeral memory handler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Also, any bug fix must start with the prefix �Bug fix:� followed by the desc
 
 Previous classification is not required if changes are simple or all belong to the same category.
 
+## [8.1.2]
+
+### Minor Changes
+- Properties `CollectionNamePostfix` and `CollectionNamePrefix` from `MemoryStoreHandlerBase` are now `virtual` instead of `abstract`.
+- In `EphemeralMemoryStoreHandler`, property `CollectionNamePrefix` has the value `ephemeral-` fixed.
+
 ## [8.1.1]
 
 ### Minor Changes

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>8.1.1</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>8.1.2</VersionPrefix>
+    <VersionSuffix>preview-1</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/MemoryStoreHandlerBase.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/MemoryStoreHandlerBase.cs
@@ -23,10 +23,10 @@ public abstract class MemoryStoreHandlerBase : IMemoryStoreHandler
     }
 
     /// <inheritdoc/>
-    public abstract string CollectionNamePostfix { get; init; }
+    public virtual string CollectionNamePostfix { get; init; }
 
     /// <inheritdoc/>
-    public abstract string CollectionNamePrefix { get; init; }
+    public virtual string CollectionNamePrefix { get; init; }
 
     /// <summary>
     /// Gets the current collection of memory stores.

--- a/src/Encamina.Enmarcha.SemanticKernel/EphemeralMemoryStoreHandler.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel/EphemeralMemoryStoreHandler.cs
@@ -35,11 +35,8 @@ internal sealed class EphemeralMemoryStoreHandler : MemoryStoreHandlerBase
         Task.Run(() => RemoveOutdatedCollectionsAsync());
     }
 
-    /// <inheritdoc />
-    public override string CollectionNamePostfix { get; init; }
-
-    /// <inheritdoc />
-    public override string CollectionNamePrefix { get; init; }
+    /// <inheritdoc/>
+    public override string CollectionNamePrefix => @"ephemeral-";
 
     private async Task RemoveOutdatedCollectionsAsync(CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
- Properties `CollectionNamePostfix` and `CollectionNamePrefix` from `MemoryStoreHandlerBase` are now `virtual` instead of `abstract`. 
- In `EphemeralMemoryStoreHandler`, property `CollectionNamePrefix` has the value `ephemeral-` fixed.