### PR TITLE
Improvements in `Encamina.Enmarcha.SemanticKernel.Connectors.Document`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,14 @@ Previous classification is not required if changes are simple or all belong to t
 
 ## [8.1.2]
 
+### Major change
+- Method `DocumentContentExtractorBase` in `DocumentContentExtractorBase` is now `public` instead of `protected`.
+
 ### Minor Changes
 - Properties `CollectionNamePostfix` and `CollectionNamePrefix` from `MemoryStoreHandlerBase` are now `virtual` instead of `abstract`.
 - In `EphemeralMemoryStoreHandler`, property `CollectionNamePrefix` has the value `ephemeral-` fixed.
+- Fixed some typos and grammatical errors (mostly on code comments).
+- Added new extension method `AddDefaultDocumentConnectorProvider` in `Encamina.Enmarcha.SemanticKernel.Connectors.Document` to get access to a default implementation of a `IDocumentConnector`.
 
 ## [8.1.1]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.2</VersionPrefix>
-    <VersionSuffix>preview-1</VersionSuffix>
+    <VersionSuffix>preview-2</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Net.Http/MediaTypeFileExtensionMapper.cs
+++ b/src/Encamina.Enmarcha.Net.Http/MediaTypeFileExtensionMapper.cs
@@ -11,7 +11,7 @@ namespace Encamina.Enmarcha.Net.Http;
 /// </summary>
 /// <remarks>
 /// The main difference with <see href="https://github.com/dotnet/aspnetcore/blob/main/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs">FileExtensionContentTypeProvider</see>
-/// is that this considers various media types per extension, which is usefull for scenarios like for example zip files which can be identified as <c>"application/zip",</c>
+/// is that this considers various media types per extension, which is useful for scenarios like for example zip files which can be identified as <c>"application/zip",</c>
 /// <c>"application/zip-compressed"</c>, or <c>"application/x-zip-compressed"</c>.
 /// </remarks>
 public sealed class MediaTypeFileExtensionMapper
@@ -445,10 +445,10 @@ public sealed class MediaTypeFileExtensionMapper
         }
 
         Mappings = new ReadOnlyDictionary<string, IEnumerable<string>>(aux);
-}
+    }
 
     /// <summary>
-    /// Gets the current mappings between extensions and media tyes.
+    /// Gets the current mappings between extensions and media types.
     /// </summary>
     public IReadOnlyDictionary<string, IEnumerable<string>> Mappings { get; }
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/DefaultDocumentContentExtractor.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/DefaultDocumentContentExtractor.cs
@@ -31,7 +31,7 @@ internal sealed class DefaultDocumentContentExtractor : DocumentContentExtractor
     }
 
     /// <inheritdoc/>
-    protected override IDocumentConnector GetDocumentConnector(string fileExtension)
+    public override IDocumentConnector GetDocumentConnector(string fileExtension)
     {
         return fileExtension.ToUpperInvariant() switch
         {

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/DocumentContentExtractorBase.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/DocumentContentExtractorBase.cs
@@ -7,7 +7,7 @@ namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document;
 /// <summary>
 /// Base class for document content extractors.
 /// </summary>
-public abstract class DocumentContentExtractorBase : IDocumentContentExtractor
+public abstract class DocumentContentExtractorBase : IDocumentConnectorProvider, IDocumentContentExtractor
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="DocumentContentExtractorBase"/> class.
@@ -40,10 +40,6 @@ public abstract class DocumentContentExtractorBase : IDocumentContentExtractor
         return TextSplitter.Split(content, LengthFunction);
     }
 
-    /// <summary>
-    /// Determines the most appropriate document connector from an specified file extension.
-    /// </summary>
-    /// <param name="fileExtension">The file extension.</param>
-    /// <returns>A valid instance of <see cref="IDocumentConnector"/> that could handle documents from the given file extension.</returns>
-    protected abstract IDocumentConnector GetDocumentConnector(string fileExtension);
+    /// <inheritdoc/>
+    public abstract IDocumentConnector GetDocumentConnector(string fileExtension);
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Extensions/IServiceCollectionExtensions.cs
@@ -10,12 +10,22 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class IServiceCollectionExtensions
 {
     /// <summary>
-    /// Adds a default implementation of <see cref="IDocumentContentExtractor"/> to the specified <see cref="IServiceCollection"/> as a singleon service.
+    /// Adds a default implementation of <see cref="IDocumentContentExtractor"/> to the specified <see cref="IServiceCollection"/> as a singleton service.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddDefaultDocumentContentExtractor(this IServiceCollection services)
     {
         return services.AddSingleton<IDocumentContentExtractor, DefaultDocumentContentExtractor>();
+    }
+
+    /// <summary>
+    /// Adds a default implementation of <see cref="IDocumentConnectorProvider"/> to the specified <see cref="IServiceCollection"/> as a singleton service.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddDefaultDocumentConnectorProvider(this IServiceCollection services)
+    {
+        return services.AddSingleton<IDocumentConnectorProvider, DefaultDocumentContentExtractor>();
     }
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/IDocumentConnectorProvider.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/IDocumentConnectorProvider.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.SemanticKernel.Plugins.Document;
+
+namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document;
+
+/// <summary>
+/// Provider interface to obtain instances of <see cref="IDocumentConnector"/>s.
+/// </summary>
+public interface IDocumentConnectorProvider
+{
+    /// <summary>
+    /// Determines the most appropriate document connector from an specified file extension.
+    /// </summary>
+    /// <param name="fileExtension">The file extension.</param>
+    /// <returns>A valid instance of <see cref="IDocumentConnector"/> that could handle documents from the given file extension.</returns>
+    protected abstract IDocumentConnector GetDocumentConnector(string fileExtension);
+}


### PR DESCRIPTION
- Method `DocumentContentExtractorBase` in `DocumentContentExtractorBase` is now `public` instead of `protected`.
- Added new extension method `AddDefaultDocumentConnectorProvider` in `Encamina.Enmarcha.SemanticKernel.Connectors.Document` to get access to a default implementation of a `IDocumentConnector`.