### PR TITLE
@rliberoff/improvements on ephemaral memory handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Previous classification is not required if changes are simple or all belong to t
 ## [8.1.2]
 
 ### Major change
-- Method `DocumentContentExtractorBase` in `DocumentContentExtractorBase` is now `public` instead of `protected`.
+- Method `GetDocumentConnector` in `DocumentContentExtractorBase` is now `public` instead of `protected`.
 
 ### Minor Changes
 - Properties `CollectionNamePostfix` and `CollectionNamePrefix` from `MemoryStoreHandlerBase` are now `virtual` instead of `abstract`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.2</VersionPrefix>
-    <VersionSuffix>preview-2</VersionSuffix>
+    <VersionSuffix>preview-3</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/IDocumentConnectorProvider.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/IDocumentConnectorProvider.cs
@@ -12,5 +12,5 @@ public interface IDocumentConnectorProvider
     /// </summary>
     /// <param name="fileExtension">The file extension.</param>
     /// <returns>A valid instance of <see cref="IDocumentConnector"/> that could handle documents from the given file extension.</returns>
-    protected abstract IDocumentConnector GetDocumentConnector(string fileExtension);
+    IDocumentConnector GetDocumentConnector(string fileExtension);
 }


### PR DESCRIPTION
- Fixed IDocumentConnectorProvider interface. Method `GetDocumentConnector` should not have visibility modifiers.