### PR TITLE
Various improvements in IMemoryStore, IMemoryManager and IMemoryStoreHandler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,14 @@ Previous classification is not required if changes are simple or all belong to t
 
 ## [8.1.2]
 
+### Braking Changes
+- Replace dependency with `IMemoryStore` for `IMemoryManager` in abstract class `MemoryStoreHandlerBase`. This affects internal types like the `EphemeralMemoryStoreHandler`.
+- Removed visibility modifiers in `IMemoryManager` interface.
+
 ### Major change
 - Method `GetDocumentConnector` in `DocumentContentExtractorBase` is now `public` instead of `protected`.
+- New `MemoryManager` property of type `IMemoryManager` in `IMemoryStoreHandler` interface to get read-only access to the underlaying memory manager.
+- New `MemoryStore` property of type `IMemoryStore` in `IMemoryManager` interface to get read-only access to the underlaying memory store.
 
 ### Minor Changes
 - Properties `CollectionNamePostfix` and `CollectionNamePrefix` from `MemoryStoreHandlerBase` are now `virtual` instead of `abstract`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.2</VersionPrefix>
-    <VersionSuffix>preview-3</VersionSuffix>
+    <VersionSuffix>preview-4</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IMemoryManager.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IMemoryManager.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.SemanticKernel.Memory;
+﻿// Ignore Spelling: Upsert
+
+using Microsoft.SemanticKernel.Memory;
 
 namespace Encamina.Enmarcha.SemanticKernel.Abstractions;
 
@@ -8,6 +10,11 @@ namespace Encamina.Enmarcha.SemanticKernel.Abstractions;
 public interface IMemoryManager
 {
     /// <summary>
+    /// Gets the instance of the memory store manage by this manager.
+    /// </summary>
+    IMemoryStore MemoryStore { get; }
+
+    /// <summary>
     /// Upserts the memory content into a collection.
     /// </summary>
     /// <param name="memoryId">The memory unique identifier.</param>
@@ -16,7 +23,7 @@ public interface IMemoryManager
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
     /// <param name="metadata">Metadata of the memory.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public Task UpsertMemoryAsync(string memoryId, string collectionName, IEnumerable<string> chunks, CancellationToken cancellationToken, IDictionary<string, string> metadata = null);
+    Task UpsertMemoryAsync(string memoryId, string collectionName, IEnumerable<string> chunks, CancellationToken cancellationToken, IDictionary<string, string> metadata = null);
 
     /// <summary>
     /// Deletes the memory content from a collection.
@@ -25,7 +32,7 @@ public interface IMemoryManager
     /// <param name="collectionName">Name of the collection from where the content will be deleted.</param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public Task DeleteMemoryAsync(string memoryId, string collectionName, CancellationToken cancellationToken);
+    Task DeleteMemoryAsync(string memoryId, string collectionName, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the memory content from a collection.
@@ -34,7 +41,7 @@ public interface IMemoryManager
     /// <param name="collectionName">Name of the collection where the content will be saved.</param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
     /// <returns>A <see cref="Task"/> containing the <see cref="MemoryContent"/>, or <see langword="null"/> if the content could not be found.</returns>
-    public Task<MemoryContent> GetMemoryAsync(string memoryId, string collectionName, CancellationToken cancellationToken);
+    Task<MemoryContent> GetMemoryAsync(string memoryId, string collectionName, CancellationToken cancellationToken);
 
     /// <summary>
     /// Upserts a batch of memory contents into a collection.
@@ -42,7 +49,7 @@ public interface IMemoryManager
     /// <param name="collectionName">Name of the collection where the content will be saved.</param>
     /// <param name="memoryContents">
     /// Dictionary with the memory contents to upsert.
-    /// The <c>key</c> in the dictionary must containt a unique identifier for the content of the memory,
+    /// The <c>key</c> in the dictionary must contain a unique identifier for the content of the memory,
     /// and the <c>value</c> of the dictionary must provide the memory content (chunks and metadata).
     /// </param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IMemoryStoreHandler.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IMemoryStoreHandler.cs
@@ -3,8 +3,8 @@
 namespace Encamina.Enmarcha.SemanticKernel.Abstractions;
 
 /// <summary>
-/// Represents types that helps working with memory stores (i.e., <see cref="IMemoryStore"/>), when sometimes
-/// it is necessary to centrally manage how some operations or actions are done.
+/// Represents types that helps working with memory stores (i.e., <see cref="IMemoryStore"/>) through a memory handler (<see cref="IMemoryManager"/>),
+/// when sometimes it is necessary to centrally manage how some operations or actions are done.
 /// </summary>
 public interface IMemoryStoreHandler
 {
@@ -17,6 +17,11 @@ public interface IMemoryStoreHandler
     /// Gets a prefix string value that can be used when creating a collection name.
     /// </summary>
     string CollectionNamePrefix { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="IMemoryManager"/> that manages the memory stored handled by this instance.
+    /// </summary>
+    IMemoryManager MemoryManager { get; }
 
     /// <summary>
     /// Gets the name of a collection from its unique identifier.

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/MemoryStoreHandlerBase.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/MemoryStoreHandlerBase.cs
@@ -14,13 +14,14 @@ public abstract class MemoryStoreHandlerBase : IMemoryStoreHandler
     /// <summary>
     /// Initializes a new instance of the <see cref="MemoryStoreHandlerBase"/> class.
     /// </summary>
-    /// <param name="memoryStore">The <see cref="IMemoryStore"/> to handle.</param>
-#pragma warning disable SKEXP0003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected MemoryStoreHandlerBase(IMemoryStore memoryStore)
-#pragma warning restore SKEXP0003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    /// <param name="memoryManager">A valid instance of <see cref="IMemoryManager"/> that manages the memory store handled by this instance.</param>
+    protected MemoryStoreHandlerBase(IMemoryManager memoryManager)
     {
-        MemoryStore = memoryStore;
+        MemoryManager = memoryManager;
     }
+
+    /// <inheritdoc/>
+    public virtual IMemoryManager MemoryManager { get; }
 
     /// <inheritdoc/>
     public virtual string CollectionNamePostfix { get; init; }
@@ -32,11 +33,6 @@ public abstract class MemoryStoreHandlerBase : IMemoryStoreHandler
     /// Gets the current collection of memory stores.
     /// </summary>
     protected IDictionary<string, MemoryStoreCollection> MemoryStoreCollectionInfo { get; } = new ConcurrentDictionary<string, MemoryStoreCollection>();
-
-    /// <summary>
-    /// Gets the current <see cref="IMemoryStore"/> handled by this instance.
-    /// </summary>
-    protected IMemoryStore MemoryStore { get; }
 
     /// <inheritdoc/>
     public virtual async Task<string> GetCollectionNameAsync(string collectionId, CancellationToken cancellationToken)
@@ -55,9 +51,9 @@ public abstract class MemoryStoreHandlerBase : IMemoryStoreHandler
             LastAccessUtc = DateTime.UtcNow,
         };
 
-        if (!await MemoryStore.DoesCollectionExistAsync(collectionName, cancellationToken))
+        if (!await MemoryManager.MemoryStore.DoesCollectionExistAsync(collectionName, cancellationToken))
         {
-            await MemoryStore.CreateCollectionAsync(collectionName, cancellationToken);
+            await MemoryManager.MemoryStore.CreateCollectionAsync(collectionName, cancellationToken);
         }
 
         return MemoryStoreCollectionInfo[collectionId].CollectionName;

--- a/src/Encamina.Enmarcha.SemanticKernel/EphemeralMemoryStoreHandler.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel/EphemeralMemoryStoreHandler.cs
@@ -20,11 +20,11 @@ internal sealed class EphemeralMemoryStoreHandler : MemoryStoreHandlerBase
     /// <summary>
     /// Initializes a new instance of the <see cref="EphemeralMemoryStoreHandler"/> class.
     /// </summary>
-    /// <param name="memoryStore">A valid instance of an <see cref="IMemoryStore"/> handled by this memory store handler.</param>
+    /// <param name="memoryManager">A valid instance of <see cref="IMemoryManager"/> that manages the memory store handled by this instance.</param>
     /// <param name="sessionManagementOptions">Configuration options for this memory store handler.</param>
     /// <param name="logger">A logger for this memory store handler.</param>
-    public EphemeralMemoryStoreHandler(IMemoryStore memoryStore, IOptionsMonitor<EphemeralMemoryStoreHandlerOptions> sessionManagementOptions, ILogger<EphemeralMemoryStoreHandler> logger)
-        : base(memoryStore)
+    public EphemeralMemoryStoreHandler(IMemoryManager memoryManager, IOptionsMonitor<EphemeralMemoryStoreHandlerOptions> sessionManagementOptions, ILogger<EphemeralMemoryStoreHandler> logger)
+        : base(memoryManager)
     {
         this.logger = logger;
 
@@ -54,7 +54,7 @@ internal sealed class EphemeralMemoryStoreHandler : MemoryStoreHandlerBase
                 foreach (var memoryStoreInfo in MemoryStoreCollectionInfo.Where(i => i.Value.LastAccessUtc < date).ToList())
                 {
                     MemoryStoreCollectionInfo.Remove(memoryStoreInfo.Key);
-                    await MemoryStore.DeleteCollectionAsync(memoryStoreInfo.Value.CollectionName, cancellationToken);
+                    await MemoryManager.MemoryStore.DeleteCollectionAsync(memoryStoreInfo.Value.CollectionName, cancellationToken);
                 }
 
                 Thread.Sleep(TimeSpan.FromMinutes(options.InactivePollingTimeMinutes));


### PR DESCRIPTION
- Replace dependency with `IMemoryStore` for `IMemoryManager` in abstract class `MemoryStoreHandlerBase`. This affects internal types like the `EphemeralMemoryStoreHandler`.
- Removed visibility modifiers in `IMemoryManager` interface.
- New `MemoryManager` property of type `IMemoryManager` in `IMemoryStoreHandler` interface to get read-only access to the underlaying memory manager.
- New `MemoryStore` property of type `IMemoryStore` in `IMemoryManager` interface to get read-only access to the underlaying memory store.