### PR TITLE
Removed unnecessary `Guards` when adding a Memory Manager and the Ephemeral Memory Store Handler. The exceptions will be thrown by the DI engine itself.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Previous classification is not required if changes are simple or all belong to t
 - Method `GetDocumentConnector` in `DocumentContentExtractorBase` is now `public` instead of `protected`.
 - New `MemoryManager` property of type `IMemoryManager` in `IMemoryStoreHandler` interface to get read-only access to the underlaying memory manager.
 - New `MemoryStore` property of type `IMemoryStore` in `IMemoryManager` interface to get read-only access to the underlaying memory store.
+- Removed unnecessary `Guards` when adding a Memory Manager and the Ephemeral Memory Store Handler. The exceptions will be thrown by the DI engine itself.
 
 ### Minor Changes
 - Properties `CollectionNamePostfix` and `CollectionNamePrefix` from `MemoryStoreHandlerBase` are now `virtual` instead of `abstract`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.2</VersionPrefix>
-    <VersionSuffix>preview-4</VersionSuffix>
+    <VersionSuffix>preview-5</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.SemanticKernel/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel/Extensions/IServiceCollectionExtensions.cs
@@ -22,14 +22,8 @@ public static class IServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-    /// <exception cref="ArgumentException">
-    /// If the <see cref="IServiceCollection"/> does not contain a service reference for the <see cref="Kernel"/> and the <see cref="IMemoryStore"/> services.
-    /// </exception>
     public static IServiceCollection AddMemoryManager(this IServiceCollection services)
     {
-        Guard.IsTrue(services.Any(service => service.ServiceType == typeof(Kernel)), @"Service `Kernel` is required to use `MemoryManager`.");
-        Guard.IsTrue(services.Any(service => service.ServiceType == typeof(IMemoryStore)), @"Service `IMemoryStore` is required to use `MemoryManager`.");
-
         services.TryAddScoped<IMemoryManager, MemoryManager>();
 
         return services;
@@ -42,13 +36,8 @@ public static class IServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="configuration">The current set of key-value application configuration parameters.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-    /// <exception cref="ArgumentException">
-    /// If the <see cref="IServiceCollection"/> does not contain a service reference for the <see cref="IMemoryStore"/> service.
-    /// </exception>
     public static IServiceCollection AddEphemeralMemoryStoreHandler(this IServiceCollection services, IConfiguration configuration)
     {
-        Guard.IsTrue(services.Any(service => service.ServiceType == typeof(IMemoryStore)), @"Service `IMemoryStore` is required to use `MemoryManager`.");
-
         services.AddOptions<EphemeralMemoryStoreHandlerOptions>()
                 .Bind(configuration.GetSection(nameof(EphemeralMemoryStoreHandlerOptions)))
                 .ValidateDataAnnotations()


### PR DESCRIPTION
- Removed unnecessary `Guards` when adding a Memory Manager and the Ephemeral Memory Store Handler. The exceptions will be thrown by the DI engine itself.