### PR TITLE
Kernel extension improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Previous classification is not required if changes are simple or all belong to t
 - Overloaded `AddDefaultDocumentConnectorProvider` and `AddDefaultDocumentContentExtractor` methods with a parameter to pass a function to calculate the length of a text and inject it as a dependency.
 - Added Readme file to all solution's projects.
 - Added event handler for `MemoryManager` operations.
+- Added new extension method `GetKernelPromptAsync` in `Encamina.Enmarcha.SemanticKernel.Extensions.KernelExtensions` to retrieve the final prompt for a given prompt using the arguments.
+- Added new extension method `GetKernelFunctionUsedTokensFromPromptAsync` in `Encamina.Enmarcha.SemanticKernel.Extensions.KernelExtensions` to obtain the total number of tokens used in generating a prompt from an inline prompt function.
+- Fixed `GetMaxTokensFromKernelFunction` in `Encamina.Enmarcha.SemanticKernel.Extensions.KernelExtensions`. Now, it considers whether the arguments are of type `OpenAIPromptExecutionSettings` when obtaining the MaxTokens.
 
 ## [8.1.1]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.2</VersionPrefix>
-    <VersionSuffix>preview-12</VersionSuffix>
+    <VersionSuffix>preview-13</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.2</VersionPrefix>
-    <VersionSuffix>preview-13</VersionSuffix>
+    <VersionSuffix>preview-14</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.SemanticKernel/Extensions/KernelExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel/Extensions/KernelExtensions.cs
@@ -286,7 +286,7 @@ public static class KernelExtensions
         // Once the service settings are retrieved, get the value of the MaxTokens property from the MaxTokens property or extension data.
         // If the `max_tokens` property is found, check is a JsonElement and try to get its value as an integer.
         // Finally, if the value is an integer, return it.
-        // In any other case (if the service settings are not found, MaxTokens property is not found or the `max_tokens` property is not found, or the value is not an integer), throw an exception.
+        // In any other case (if the service settings are not found, MaxTokens property is not found or the `max_tokens` property is not found, or the value is not an integer), return 0.
         if (kernel.ServiceSelector.TrySelectAIService<IChatCompletionService>(kernel, function, arguments, out _, out var serviceSettings) ||
             kernel.ServiceSelector.TrySelectAIService<ITextGenerationService>(kernel, function, arguments, out _, out serviceSettings))
         {


### PR DESCRIPTION
## Description
This PR focus is on refining the `Encamina.Enmarcha.SemanticKernel.Extensions.KernelExtensions` class to enhance functionality and address specific use cases.

## Code Changes
### GetKernelPromptAsync:

This method allows users to retrieve the final prompt for a given prompt using the provided arguments.

### GetKernelFunctionUsedTokensFromPromptAsync:

This method facilitates the retrieval of the total number of tokens used in generating a prompt from an inline prompt function.

### Fix in GetMaxTokensFromKernelFunction:

It now considers whether the arguments are of type `OpenAIPromptExecutionSettings` when obtaining the MaxTokens. This method is now used in the `QuestionAnsweringPlugin` to calculate the number of tokens.

## How Has This Been Tested?
Tests have been added in `KernelExtensionsTest` covering different cases.