### PR TITLE
Update Semantic Kernel from v1.1.0 to v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Previous classification is not required if changes are simple or all belong to t
 
 ## [8.1.2]
 
+### Important
+
+This version updates the `Semantic Kernel` library from version `1.1.0` to `1.2.0`, which introduces minor changes in the code.
+
+More information about these warnings is available here: https://github.com/microsoft/semantic-kernel/releases/tag/dotnet-1.2.0
+
 ### Breaking Changes
 - Replace dependency with `IMemoryStore` for `IMemoryManager` in abstract class `MemoryStoreHandlerBase`. This affects internal types like the `EphemeralMemoryStoreHandler`.
 - Removed visibility modifiers in `IMemoryManager` interface.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.2</VersionPrefix>
-    <VersionSuffix>preview-12</VersionSuffix>
+    <VersionSuffix>preview-13</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering.csproj
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.1.0-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.2.0-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
@@ -17,8 +17,8 @@
     </PropertyGroup>
 
     <ItemGroup>        
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.1.0" PrivateAssets="none" />
-        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.1.0" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.2.0" PrivateAssets="none" />
+        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.2.0" />
         <PackageReference Include="SharpToken" Version="1.2.14" />
     </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.1.0-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.2.0-alpha" />
     <PackageReference Include="PdfPig" Version="0.1.8" />
   </ItemGroup>
 
@@ -44,7 +44,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Memory/Encamina.Enmarcha.SemanticKernel.Connectors.Memory.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Memory/Encamina.Enmarcha.SemanticKernel.Connectors.Memory.csproj
@@ -21,7 +21,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.1.0-alpha" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.2.0-alpha" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
@@ -27,7 +27,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.2.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The Semantic Kernel libraries have been updated to version 1.2.0. I generate an upgrade to have the ENMARCHA libraries updated to this latest version.