### PR TITLE
Added keyphrases with locale prompt function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Previous classification is not required if changes are simple or all belong to t
 
 ### Minor Changes
 - Added `Description` property in `VersionSwaggerGenOptions`.
+- New text prompt function for extract KeyPhrases with specified locale, `KeyPhrasesLocaled`.
+- Added an example of using `KeyPhrasesLocaled` in `Encamina.Enmarcha.Samples.SemanticKernel.Text`.
 
 ## [8.1.2]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.3</VersionPrefix>
-    <VersionSuffix>preview-01</VersionSuffix>
+    <VersionSuffix>preview-02</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.Text/Example.cs
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.Text/Example.cs
@@ -14,14 +14,12 @@ internal class Example
         Alexandre acquired work with Louis - Philippe, Duke of Orléans, then as a writer, a career which led to early success.Decades later, after the election of Louis - Napoléon Bonaparte in 1851, Dumas fell from favour and left France for Belgium, where he stayed for several years. He moved to Russia for a few years and then to Italy.In 1861, he founded and published the newspaper L'Indépendent, which supported Italian unification. He returned to Paris in 1864.
         English playwright Watts Phillips, who knew Dumas in his later life, described him as ""the most generous, large - hearted being in the world.He also was the most delightfully amusing and egotistical creature on the face of the earth.His tongue was like a windmill – once set in motion, you never knew when he would stop, especially if the theme was himself.""";
 
-    /// <inheritdoc/>
     public Example(Kernel kernel)
     {
         this.kernel = kernel;
         Console.WriteLine($"# Context: {input} \n");
     }
 
-    /// <inheritdoc/>
     public async Task TestSummaryAsync()
     {
         var summaryArguments = new KernelArguments()
@@ -37,7 +35,6 @@ internal class Example
         Console.WriteLine($"# Summary: {result} \n");
     }
 
-    /// <inheritdoc/>
     public async Task TextKeyPhrasesAsync()
     {
         var keyPhrasesArguments = new KernelArguments()
@@ -46,10 +43,26 @@ internal class Example
             [PluginsInfo.TextPlugin.Functions.KeyPhrases.Parameters.TopKeyphrases] = 2,
         };
 
-        var functionSummarize = kernel.Plugins.GetFunction(PluginsInfo.TextPlugin.Name, PluginsInfo.TextPlugin.Functions.KeyPhrases.Name);
+        var functionKeyPhrases = kernel.Plugins.GetFunction(PluginsInfo.TextPlugin.Name, PluginsInfo.TextPlugin.Functions.KeyPhrases.Name);
 
-        var result = await kernel.InvokeAsync<string>(functionSummarize, keyPhrasesArguments);
+        var result = await kernel.InvokeAsync<string>(functionKeyPhrases, keyPhrasesArguments);
 
         Console.WriteLine($"# Key Phrases: {result} \n");
+    }
+
+    public async Task TextKeyPhrasesLocaledAsync()
+    {
+        var keyPhrasesArguments = new KernelArguments()
+        {
+            [PluginsInfo.TextPlugin.Functions.KeyPhrasesLocaled.Parameters.Input] = input,
+            [PluginsInfo.TextPlugin.Functions.KeyPhrasesLocaled.Parameters.Locale] = "Italian",
+            [PluginsInfo.TextPlugin.Functions.KeyPhrasesLocaled.Parameters.TopKeyphrases] = 3,
+        };
+
+        var functionKeyPhrasesLocaled = kernel.Plugins.GetFunction(PluginsInfo.TextPlugin.Name, PluginsInfo.TextPlugin.Functions.KeyPhrasesLocaled.Name);
+
+        var result = await kernel.InvokeAsync<string>(functionKeyPhrasesLocaled, keyPhrasesArguments);
+
+        Console.WriteLine($"# Key Phrases Localed: {result} \n");
     }
 }

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.Text/Program.cs
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.Text/Program.cs
@@ -48,5 +48,7 @@ internal static class Program
         await example.TestSummaryAsync();
 
         await example.TextKeyPhrasesAsync();
+
+        await example.TextKeyPhrasesLocaledAsync();
     }
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Encamina.Enmarcha.SemanticKernel.Plugins.Text.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Encamina.Enmarcha.SemanticKernel.Plugins.Text.csproj
@@ -11,6 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Plugins\TextPlugin\KeyPhrasesLocaled\config.json" />
+    <EmbeddedResource Include="Plugins\TextPlugin\KeyPhrasesLocaled\skprompt.txt" />
     <EmbeddedResource Include="Plugins\TextPlugin\KeyPhrases\config.json" />
     <EmbeddedResource Include="Plugins\TextPlugin\KeyPhrases\skprompt.txt" />
     <EmbeddedResource Include="Plugins\TextPlugin\Summarize\config.json" />
@@ -22,7 +24,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/KeyPhrases/skprompt.txt
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/KeyPhrases/skprompt.txt
@@ -1,5 +1,5 @@
 The task is to EXTRACT JUST {{$topKeyphrases}} of the most significant keyphrases.
-ALWAYS return EXACTLY {{$topKeyphrases}} keyphares, no less and no more.
+ALWAYS return EXACTLY {{$topKeyphrases}} keyphrases, no less and no more.
 DO NOT enumerate keyphrases.
 Each keyphrase MUST BE ALWAYS separated by a new line.
 Each keyphrases MUST BE ALWAYS in the same language as the input text.

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/KeyPhrasesLocaled/config.json
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/KeyPhrasesLocaled/config.json
@@ -1,0 +1,31 @@
+{
+  "schema": 1,
+  "description": "Extract keyphrases from a given text or any text document in specifed locale",
+  "execution_settings": {
+    "default": {
+      "max_tokens": 1250,
+      "temperature": 0.0,
+      "top_p": 1.0,
+      "presence_penalty": 0.0,
+      "frequency_penalty": 0.0
+    }
+  },
+  "input_variables": [
+    {
+      "name": "input",
+      "description": "Text to analyze and extract keyphrases from",
+      "is_required": true
+    },
+    {
+      "name": "locale",
+      "description": "Language in which the keyphrases will be generated",
+      "is_required": true
+    },
+    {
+      "name": "topKeyphrases",
+      "description": "Top number of keyphrases to extract",
+      "default": "2",
+      "is_required": false
+    }
+  ]
+}

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/KeyPhrasesLocaled/skprompt.txt
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/KeyPhrasesLocaled/skprompt.txt
@@ -1,0 +1,11 @@
+The task is to EXTRACT JUST {{$topKeyphrases}} of the most significant keyphrases.
+ALWAYS return EXACTLY {{$topKeyphrases}} keyphares, no less and no more.
+DO NOT enumerate keyphrases.
+Each keyphrase MUST BE ALWAYS separated by a new line.
+
+[INPUT]
+{{$input}}
+
+[KEYPHRASES]
+
+Each keyphrase MUST BE ALWAYS in {{$locale}} language.

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/KeyPhrasesLocaled/skprompt.txt
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/KeyPhrasesLocaled/skprompt.txt
@@ -1,5 +1,5 @@
 The task is to EXTRACT JUST {{$topKeyphrases}} of the most significant keyphrases.
-ALWAYS return EXACTLY {{$topKeyphrases}} keyphares, no less and no more.
+ALWAYS return EXACTLY {{$topKeyphrases}} keyphrases, no less and no more.
 DO NOT enumerate keyphrases.
 Each keyphrase MUST BE ALWAYS separated by a new line.
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/PluginsInfo.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/PluginsInfo.cs
@@ -1,7 +1,7 @@
 ﻿namespace Encamina.Enmarcha.SemanticKernel.Plugins.Text;
 
 /// <summary>
-/// Information about plguins in this assembly.
+/// Information about plugins in this assembly.
 /// </summary>
 public static class PluginsInfo
 {
@@ -39,6 +39,38 @@ public static class PluginsInfo
                     /// The name of the «input» parameter, which represents the text to analyze and extract keyphrases from.
                     /// </summary>
                     public static readonly string Input = nameof(Input).ToLowerInvariant();
+
+                    /// <summary>
+                    /// The name of the «topKeyphrases» parameter, which represents the maximum or top number of keyphrases to extract.
+                    /// </summary>
+                    public static readonly string TopKeyphrases = nameof(TopKeyphrases).ToLowerInvariant();
+                }
+            }
+
+            /// <summary>
+            /// Information about the «KeyPhrasesLocaled» function.
+            /// </summary>
+            public static class KeyPhrasesLocaled
+            {
+                /// <summary>
+                /// The name of the function.
+                /// </summary>
+                public static readonly string Name = nameof(KeyPhrasesLocaled);
+
+                /// <summary>
+                /// Information about the function's parameters.
+                /// </summary>
+                public static class Parameters
+                {
+                    /// <summary>
+                    /// The name of the «input» parameter, which represents the text to analyze and extract keyphrases from.
+                    /// </summary>
+                    public static readonly string Input = nameof(Input).ToLowerInvariant();
+
+                    /// <summary>
+                    /// The name of the «locale» parameter, which represents the language in which the keyphrases will be generated.
+                    /// </summary>
+                    public static readonly string Locale = nameof(Locale).ToLowerInvariant();
 
                     /// <summary>
                     /// The name of the «topKeyphrases» parameter, which represents the maximum or top number of keyphrases to extract.


### PR DESCRIPTION
## Description
Added a new feature to the text plugins for extracting key phrases from a text in a specific language. 
I have decided to specify in the last line that it must exclusively use the locale indicated in its responses,
https://github.com/Encamina/enmarcha/blob/9966835ff9dc10bafed05d1d80b770825e7d2c8f/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/KeyPhrasesLocaled/skprompt.txt#L11
because, with long texts, it seemed to be _forgotten_ if placed in the first block of the prompt where the instructions are.

## Code Changes
I have chosen not to use the existing prompt function (KeyPhrases) because if I modified this line,
https://github.com/Encamina/enmarcha/blob/9966835ff9dc10bafed05d1d80b770825e7d2c8f/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/KeyPhrases/skprompt.txt#L5
and indicated to use the passed locale (for example,  `Each keyphrase MUST BE ALWAYS in {{$locale}} language`) with a default value (English), this would be a breaking change. Anyone using this plugin, starting from a text in Spanish, would switch from generating keyphrases in Spanish to generating them in English.

I understand that this can be resolved with Handlebars templates (using conditionals), but there are KernelExtensions functions (GetKernelFunctionPromptAsync) that still do not have support for Handlebars.

## How Has This Been Tested?
I have added, within the examples (`Encamina.Enmarcha.Samples.SemanticKernel.Text`), the execution of this new prompt function.