### PR TITLE
Added translate prompt function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Previous classification is not required if changes are simple or all belong to t
 - Added `Description` property in `VersionSwaggerGenOptions`.
 - New text prompt function for extract KeyPhrases with specified locale, `KeyPhrasesLocaled`.
 - Added an example of using `KeyPhrasesLocaled` in `Encamina.Enmarcha.Samples.SemanticKernel.Text`.
+- New text prompt function for translate texts, `Translate`.
+- Added an example of using `Translate` in `Encamina.Enmarcha.Samples.SemanticKernel.Text`.
 
 ## [8.1.2]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.3</VersionPrefix>
-    <VersionSuffix>preview-02</VersionSuffix>
+    <VersionSuffix>preview-03</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.Text/Example.cs
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.Text/Example.cs
@@ -65,4 +65,19 @@ internal class Example
 
         Console.WriteLine($"# Key Phrases Localed: {result} \n");
     }
+
+    public async Task TextTranslateAsync()
+    {
+        var translateArguments = new KernelArguments()
+        {
+            [PluginsInfo.TextPlugin.Functions.Translate.Parameters.Input] = input,
+            [PluginsInfo.TextPlugin.Functions.Translate.Parameters.Locale] = "Spanish",
+        };
+
+        var functionTranslate = kernel.Plugins.GetFunction(PluginsInfo.TextPlugin.Name, PluginsInfo.TextPlugin.Functions.Translate.Name);
+
+        var result = await kernel.InvokeAsync<string>(functionTranslate, translateArguments);
+
+        Console.WriteLine($"# Translation: {result} \n");
+    }
 }

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.Text/Program.cs
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.Text/Program.cs
@@ -50,5 +50,7 @@ internal static class Program
         await example.TextKeyPhrasesAsync();
 
         await example.TextKeyPhrasesLocaledAsync();
+
+        await example.TextTranslateAsync();
     }
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Encamina.Enmarcha.SemanticKernel.Plugins.Text.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Encamina.Enmarcha.SemanticKernel.Plugins.Text.csproj
@@ -17,6 +17,8 @@
     <EmbeddedResource Include="Plugins\TextPlugin\KeyPhrases\skprompt.txt" />
     <EmbeddedResource Include="Plugins\TextPlugin\Summarize\config.json" />
     <EmbeddedResource Include="Plugins\TextPlugin\Summarize\skprompt.txt" />
+    <EmbeddedResource Include="Plugins\TextPlugin\Translate\config.json" />
+    <EmbeddedResource Include="Plugins\TextPlugin\Translate\skprompt.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/Translate/config.json
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/Translate/config.json
@@ -1,0 +1,25 @@
+{
+  "schema": 1,
+  "description": "Translate a given input text",
+  "execution_settings": {
+    "default": {
+      "max_tokens": 2000,
+      "temperature": 0.1,
+      "top_p": 1.0,
+      "presence_penalty": 0.0,
+      "frequency_penalty": 0.0
+    }
+  },
+  "input_variables": [
+    {
+      "name": "input",
+      "description": "The input text to translate",
+      "is_required": true
+    },   
+    {
+      "name": "locale",
+      "description": "Language in which the translation will be generated",      
+      "is_required": true
+    }
+  ]
+}

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/Translate/skprompt.txt
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/Plugins/TextPlugin/Translate/skprompt.txt
@@ -1,0 +1,11 @@
+Your task is TO TRANSLATE the INPUT text into the '{{$locale}}' language.
+If the INPUT text is already in the '{{$locale}}' language, you must return the INPUT text without altering it.
+MAKE SURE YOU ONLY USE '{{$locale}}' language.
+
+
+[INPUT]
+
+{{$input}}
+
+[TRANSLATION]
+

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/PluginsInfo.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Text/PluginsInfo.cs
@@ -110,6 +110,33 @@ public static class PluginsInfo
                     public static readonly string Locale = nameof(Locale).ToLowerInvariant();
                 }
             }
+
+            /// <summary>
+            /// Information about the «Translate» function.
+            /// </summary>
+            public static class Translate
+            {
+                /// <summary>
+                /// The name of the function.
+                /// </summary>
+                public static readonly string Name = nameof(Translate);
+
+                /// <summary>
+                /// Information about the function's parameters.
+                /// </summary>
+                public static class Parameters
+                {
+                    /// <summary>
+                    /// The name of the «input» parameter, which represents the text to translate.
+                    /// </summary>
+                    public static readonly string Input = nameof(Input).ToLowerInvariant();
+
+                    /// <summary>
+                    /// The name of the «locale» parameter, which represents the language in which the translation will be generated.
+                    /// </summary>
+                    public static readonly string Locale = nameof(Locale).ToLowerInvariant();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Added a new feature to the text plugins for translate a text in a specific language. 

## How Has This Been Tested?
I have added, within the examples (`Encamina.Enmarcha.Samples.SemanticKernel.Text`), the execution of this new prompt function.