### PR TITLE
Temporary workaround for handling Http NotFound exception in MemoryStoreExtender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Previous classification is not required if changes are simple or all belong to t
 - Added an example of using `KeyPhrasesLocaled` in `Encamina.Enmarcha.Samples.SemanticKernel.Text`.
 - New text prompt function for translate texts, `Translate`.
 - Added an example of using `Translate` in `Encamina.Enmarcha.Samples.SemanticKernel.Text`.
+- Bug fix: Temporary workaround for handling Http NotFound exception in `MemoryStoreExtender`. [(#72)](https://github.com/Encamina/enmarcha/issues/72)
 
 ## [8.1.2]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.3</VersionPrefix>
-    <VersionSuffix>preview-03</VersionSuffix>
+    <VersionSuffix>preview-04</VersionSuffix>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
## Description

This pull request addresses an issue related to [issue](https://github.com/Encamina/enmarcha/issues/72) (though it does not close it). The PR introduces a temporary fix for an error identified in Semantic Kernel. The issue arises when utilizing the AzureAISearch connector, specifically when attempting to retrieve data from the memory store for a non-existent item. Instead of gracefully handling this scenario by returning null, an exception is thrown.

## Changes Made
- Implements a temporary fix to handle the Http NotFound exception in the `MemoryStore.GetAsync` method.
- Adds a try-catch block to capture the exception and prevent disruption in case of a non-existent item in the memory store.
- Includes a note in the code to emphasize that this fix is temporary and should be removed once the underlying issue in Semantic Kernel is resolved.

**Note:** This fix is introduced to mitigate the current behavior of the AzureAISearch Memory Store until a permanent solution is provided in Semantic Kernel.

## Related Issues
- Fixes [issue #72](https://github.com/Encamina/enmarcha/issues/72) indirectly by addressing a specific error mentioned in the issue.

