### PR TITLE
Added Exists method to MemoryStoreExtender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Previous classification is not required if changes are simple or all belong to t
 - New text prompt function for translate texts, `Translate`.
 - Added an example of using `Translate` in `Encamina.Enmarcha.Samples.SemanticKernel.Text`.
 - Bug fix: Temporary workaround for handling Http NotFound exception in `MemoryStoreExtender`. [(#72)](https://github.com/Encamina/enmarcha/issues/72)
+- Added new method `ExistsMemoryAsync` in `MemoryStoreExtender`.
 
 ## [8.1.2]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.3</VersionPrefix>
-    <VersionSuffix>preview-04</VersionSuffix>
+    <VersionSuffix>preview-05</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IMemoryStoreExtender.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IMemoryStoreExtender.cs
@@ -60,10 +60,19 @@ public interface IMemoryStoreExtender
     /// Gets the memory content from a collection.
     /// </summary>
     /// <param name="memoryId">The memory unique identifier.</param>
-    /// <param name="collectionName">Name of the collection where the content will be saved.</param>
+    /// <param name="collectionName">Name of the collection where the content will be retrieved.</param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
     /// <returns>A <see cref="Task"/> containing the <see cref="MemoryContent"/>, or <see langword="null"/> if the content could not be found.</returns>
     Task<MemoryContent> GetMemoryAsync(string memoryId, string collectionName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Checks if the memory exists in a collection.
+    /// </summary>
+    /// <param name="memoryId">The memory unique identifier.</param>
+    /// <param name="collectionName">Name of the collection where the memoryId will be searched.</param>
+    /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+    /// <returns><c>true</c> if the memory exists; otherwise, <c>false</c>.</returns>
+    Task<bool> ExistsMemoryAsync(string memoryId, string collectionName, CancellationToken cancellationToken);
 
     /// <summary>
     /// Upserts a batch of memory contents into a collection.

--- a/src/Encamina.Enmarcha.SemanticKernel/MemoryStoreExtender.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel/MemoryStoreExtender.cs
@@ -87,6 +87,14 @@ public class MemoryStoreExtender : IMemoryStoreExtender
     }
 
     /// <inheritdoc/>
+    public async Task<bool> ExistsMemoryAsync(string memoryId, string collectionName, CancellationToken cancellationToken)
+    {
+        var chunkSize = await GetChunkSize(memoryId, collectionName, cancellationToken);
+
+        return chunkSize > 0;
+    }
+
+    /// <inheritdoc/>
     public virtual async IAsyncEnumerable<string> BatchUpsertMemoriesAsync(string collectionName, IDictionary<string, MemoryContent> memoryContents, Kernel kernel, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var memoryRecords = new List<MemoryRecord>();


### PR DESCRIPTION
## Description:
This PR introduces a new method to `MemoryStoreExtender` for checking the existence of a memory ID within a collection. 

### Notes:
While this behavior could be "simulated" using the `GetMemoryAsync` method, it's important to note that `GetMemoryAsync` retrieves all the associated "chunks" with the identifier, leading to performance loss and unnecessary data retrieval from the `MemoryStore`.