### PR TITLE
Added locale parameter to QuestionAnsweringPlugin functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Previous classification is not required if changes are simple or all belong to t
 - Added an example of using `Translate` in `Encamina.Enmarcha.Samples.SemanticKernel.Text`.
 - Bug fix: Temporary workaround for handling Http NotFound exception in `MemoryStoreExtender`. [(#72)](https://github.com/Encamina/enmarcha/issues/72)
 - Added new method `ExistsMemoryAsync` in `MemoryStoreExtender`.
+- Added a new optional parameter `Locale` to the functions of `QuestionAnsweringPlugin`, to specify the language of the response.
 
 ## [8.1.2]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.3</VersionPrefix>
-    <VersionSuffix>preview-05</VersionSuffix>
+    <VersionSuffix>preview-06</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/TestQuestionAnswering.cs
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/TestQuestionAnswering.cs
@@ -54,7 +54,8 @@ to vote.";
             [PluginsInfo.QuestionAnsweringPlugin.Functions.QuestionAnsweringFromMemoryQuery.Parameters.CollectionsStr] = "my-collection",
             [PluginsInfo.QuestionAnsweringPlugin.Functions.QuestionAnsweringFromMemoryQuery.Parameters.MinRelevance] = 0.8,
             [PluginsInfo.QuestionAnsweringPlugin.Functions.QuestionAnsweringFromMemoryQuery.Parameters.ResultsLimit] = 1,
-            [PluginsInfo.QuestionAnsweringPlugin.Functions.QuestionAnsweringFromMemoryQuery.Parameters.ResponseTokenLimit] = 300
+            [PluginsInfo.QuestionAnsweringPlugin.Functions.QuestionAnsweringFromMemoryQuery.Parameters.ResponseTokenLimit] = 300,
+            [PluginsInfo.QuestionAnsweringPlugin.Functions.QuestionAnsweringFromMemoryQuery.Parameters.Locale] = "Italian",
         };
 
         Console.WriteLine($"# Question: {input} \n");

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Plugins/QuestionAnsweringPlugin.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Plugins/QuestionAnsweringPlugin.cs
@@ -155,7 +155,7 @@ ALWAYS RESPOND with a FINAL ANSWER, DO NOT CONTINUE the conversation.
 
     private static string GetAnswerLocale(string locale)
     {
-        return string.IsNullOrEmpty(locale)
+        return string.IsNullOrWhiteSpace(locale)
             ? "the SAME LANGUAGE as the QUESTION"
             : $"{locale} LANGUAGE";
     }

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/PluginsInfo.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/PluginsInfo.cs
@@ -48,6 +48,11 @@ public static class PluginsInfo
                     /// The name of the «input» parameter, which represents the question to answer with information from the context (<see cref="Context"/>).
                     /// </summary>
                     public static readonly string Input = nameof(Input).ToLowerInvariant();
+
+                    /// <summary>
+                    /// The name of the «locale» parameter, which represents the language in which the response is generated. This parameter is optional. If not provided, the input (<see cref="Input"/>) language is used.
+                    /// </summary>
+                    public static readonly string Locale = nameof(Locale).ToLowerInvariant();
                 }
             }
 
@@ -99,6 +104,11 @@ public static class PluginsInfo
                     /// The name of the «resultsLimit» parameter, which represents the maximum number of results per queried collection.
                     /// </summary>
                     public static readonly string ResultsLimit = nameof(ResultsLimit).ToLowerInvariant();
+
+                    /// <summary>
+                    /// The name of the «locale» parameter, which represents the language in which the response is generated. This parameter is optional. If not provided, the question (<see cref="Question"/>) language is used.
+                    /// </summary>
+                    public static readonly string Locale = nameof(Locale).ToLowerInvariant();
                 }
             }
         }


### PR DESCRIPTION
## Description
Introduces a new parameter, `Locale`, to the `QuestionAnsweringFromMemoryQueryAsync` and `QuestionAnsweringFromContextAsync` functions. This optional parameter is used to specify the output language of the result. If not provided, the original functionality remains unchanged (no breaking change); in other words, the response remains in the same language as the question.

## How Has This Been Tested?
I have added, within the examples (`Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering`), the new parameter.