### PR TITLE
Remove MemoryStoreExtender workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,7 @@ Previous classification is not required if changes are simple or all belong to t
   - Updated `Microsoft.SemanticKernel.Plugins.Document` from `1.3.1-alpha` to `1.4.0-alpha`.
   - Updated `Microsoft.SemanticKernel.Plugins.Memory` from `1.3.1-alpha` to `1.4.0-alpha`.
   - Updated `System.Text.Json` from `8.0.1` to `8.0.2`.
-
-### Major Changes
 - Bug fix ([Issue 72](https://github.com/Encamina/enmarcha/issues/72)). Removed `MemoryStoreExtender` workaround after updating to `Microsoft.SemanticKernel.Connectors.AzureAISearch` version `1.4.0-alpha` which resolves the issue.
-
 
 ## [8.1.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,31 @@ Also, any bug fix must start with the prefix �Bug fix:� followed by the desc
 
 Previous classification is not required if changes are simple or all belong to the same category.
 
+## [8.1.4]
+
+### Major Changes
+- Updated dependencies:
+  - Updated `Microsoft.AspNetCore.Authentication.JwtBearer` from `8.0.1` to `8.0.2`.
+  - Updated `Microsoft.AspNetCore.Authentication.OpenIdConnect` from `8.0.1` to `8.0.2`.
+  - Updated `Microsoft.Azure.Cosmos` from `3.38.0` to `3.38.1`.
+  - Updated `Microsoft.EntityFrameworkCore` from `8.0.1` to `8.0.2`.
+  - Updated `Microsoft.EntityFrameworkCore.SqlServer` from `8.0.1` to `8.0.2`.
+  - Updated `Microsoft.Extensions.Azure` from `1.7.1` to `1.7.2`.  
+  - Updated `Microsoft.Extensions.Options` from `8.0.1` to `8.0.2`.
+  - Updated `Microsoft.NET.Test.Sdk` from `17.8.0` to `17.9.0`.
+  - Updated `Microsoft.SemanticKernel.Abstractions` from `1.3.1` to `1.4.0`.
+  - Updated `Microsoft.SemanticKernel.Connectors.AzureAISearch` from `1.3.1-alpha` to `1.4.0-alpha`. This does fix the [Issue 72](https://github.com/Encamina/enmarcha/issues/72).
+  - Updated `Microsoft.SemanticKernel.Connectors.OpenAI` from `1.3.1` to `1.4.0`.
+  - Updated `Microsoft.SemanticKernel.Connectors.Qdrant` from `1.3.1-alpha` to `1.4.0-alpha`.
+  - Updated `Microsoft.SemanticKernel.Core` from `1.3.1` to `1.4.0`.
+  - Updated `Microsoft.SemanticKernel.Plugins.Document` from `1.3.1-alpha` to `1.4.0-alpha`.
+  - Updated `Microsoft.SemanticKernel.Plugins.Memory` from `1.3.1-alpha` to `1.4.0-alpha`.
+  - Updated `System.Text.Json` from `8.0.1` to `8.0.2`.
+
+### Major Changes
+- Bug fix ([Issue 72](https://github.com/Encamina/enmarcha/issues/72)). Removed `MemoryStoreExtender` workaround after updating to `Microsoft.SemanticKernel.Connectors.AzureAISearch` version `1.4.0-alpha` which resolves the issue.
+
+
 ## [8.1.3]
 
 ### Breaking Changes  

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>8.1.3</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>8.1.4</VersionPrefix>
+    <VersionSuffix>preview-01</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,6 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.4</VersionPrefix>
-    <VersionSuffix>preview-01</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/samples/Data/Encamina.Enmarcha.Samples.Data.EntityFramework/Encamina.Enmarcha.Samples.Data.EntityFramework.csproj
+++ b/samples/Data/Encamina.Enmarcha.Samples.Data.EntityFramework/Encamina.Enmarcha.Samples.Data.EntityFramework.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>
 

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering.csproj
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.3.1-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.4.0-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Encamina.Enmarcha.AI.Abstractions/Encamina.Enmarcha.AI.Abstractions.csproj
+++ b/src/Encamina.Enmarcha.AI.Abstractions/Encamina.Enmarcha.AI.Abstractions.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Encamina.Enmarcha.AI.OpenAI.Azure/Encamina.Enmarcha.AI.OpenAI.Azure.csproj
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Azure/Encamina.Enmarcha.AI.OpenAI.Azure.csproj
@@ -10,9 +10,9 @@
 
     <ItemGroup>
         <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.13" />
-        <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.1" />
+        <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.2" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     </ItemGroup>

--- a/src/Encamina.Enmarcha.AI.TextsTranslation.Azure/Encamina.Enmarcha.AI.TextsTranslation.Azure.csproj
+++ b/src/Encamina.Enmarcha.AI.TextsTranslation.Azure/Encamina.Enmarcha.AI.TextsTranslation.Azure.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -46,7 +46,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Encamina.Enmarcha.AI/Encamina.Enmarcha.AI.csproj
+++ b/src/Encamina.Enmarcha.AI/Encamina.Enmarcha.AI.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Encamina.Enmarcha.AspNet.Mvc/Encamina.Enmarcha.AspNet.Mvc.csproj
+++ b/src/Encamina.Enmarcha.AspNet.Mvc/Encamina.Enmarcha.AspNet.Mvc.csproj
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.Core/Encamina.Enmarcha.Core.csproj
+++ b/src/Encamina.Enmarcha.Core/Encamina.Enmarcha.Core.csproj
@@ -12,7 +12,7 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
       <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
       <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
-      <PackageReference Include="System.Text.Json" Version="8.0.1" />
+      <PackageReference Include="System.Text.Json" Version="8.0.2" />
     </ItemGroup>
 
     <ItemGroup>
@@ -31,7 +31,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="README.md" Pack="true" PackagePath="\"/>
+        <None Include="README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>

--- a/src/Encamina.Enmarcha.Data.Cosmos/Encamina.Enmarcha.Data.Cosmos.csproj
+++ b/src/Encamina.Enmarcha.Data.Cosmos/Encamina.Enmarcha.Data.Cosmos.csproj
@@ -13,10 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.38.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
   </ItemGroup>

--- a/src/Encamina.Enmarcha.Data.EntityFramework/Encamina.Enmarcha.Data.EntityFramework.csproj
+++ b/src/Encamina.Enmarcha.Data.EntityFramework/Encamina.Enmarcha.Data.EntityFramework.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -17,7 +17,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
@@ -17,8 +17,8 @@
     </PropertyGroup>
 
     <ItemGroup>        
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.3.1" PrivateAssets="none" />
-        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.3.1" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.4.0" PrivateAssets="none" />
+        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.4.0" />
         <PackageReference Include="SharpToken" Version="1.2.15" />
     </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.3.1-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.4.0-alpha" />
     <PackageReference Include="PdfPig" Version="0.1.8" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Memory/Encamina.Enmarcha.SemanticKernel.Connectors.Memory.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Memory/Encamina.Enmarcha.SemanticKernel.Connectors.Memory.csproj
@@ -21,8 +21,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.3.1-alpha" />
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.3.1-alpha" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.4.0-alpha" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.4.0-alpha" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.3.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.4.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.3.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Encamina.Enmarcha.SemanticKernel/MemoryStoreExtender.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel/MemoryStoreExtender.cs
@@ -1,11 +1,8 @@
 ﻿// Ignore Spelling: Upsert
 
 using System.Collections.ObjectModel;
-using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
-
-using Azure;
 
 using Encamina.Enmarcha.SemanticKernel.Abstractions;
 using Encamina.Enmarcha.SemanticKernel.Abstractions.Events;
@@ -144,21 +141,7 @@ public class MemoryStoreExtender : IMemoryStoreExtender
     private async Task<int> GetChunkSize(string memoryId, string collectionName, CancellationToken cancellationToken)
     {
         var key = BuildMemoryIdentifier(memoryId, 0);
-        MemoryRecord firstMemoryChunk = null;
-
-        try
-        {
-            firstMemoryChunk = await MemoryStore.GetAsync(collectionName, key, cancellationToken: cancellationToken);
-        }
-        catch (RequestFailedException e) when (e.Status == (int)HttpStatusCode.NotFound)
-        {
-            // At this point, we need to catch the NotFound exception. This is necessary because, in the case of Azure AI Search Memory Store,
-            // if the element does not exist, it throws an exception instead of returning a null value, which would be the expected behavior.
-            // We have opened an issue in Semantic Kernel and also an issue in ENMARCHA to track the progress of this issue and remove this try/catch block once it is resolved.
-            // Issue ENMARCHA: https://github.com/Encamina/enmarcha/issues/72
-
-            /* Do nothing */
-        }
+        var firstMemoryChunk = await MemoryStore.GetAsync(collectionName, key, cancellationToken: cancellationToken);
 
         if (firstMemoryChunk == null)
         {

--- a/src/Encamina.Enmarcha.Testing/Encamina.Enmarcha.Testing.csproj
+++ b/src/Encamina.Enmarcha.Testing/Encamina.Enmarcha.Testing.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Bogus" Version="35.4.0" />
   </ItemGroup>
     
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/tst/Directory.Build.targets
+++ b/tst/Directory.Build.targets
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>   
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />    
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.analyzers" Version="1.10.0" />


### PR DESCRIPTION
- This PR removes the workaround previously implemented in `MemoryStoreExtender`, #72 . The root cause of this workaround was identified in the Semantic Kernel ([issue](https://github.com/microsoft/semantic-kernel/issues/4952)), and it has been resolved in [version 1.4.0](https://github.com/microsoft/semantic-kernel/releases/tag/dotnet-1.4.0).
- Dependencies have been updated.
- Version 8.1.4-preview-01 has been generated.