### PR TITLE
@lmarcos/sk question function improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Also, any bug fix must start with the prefix �Bug fix:� followed by the desc
 
 Previous classification is not required if changes are simple or all belong to the same category.
 
+## [8.1.5]
+
+### Breaking Changes 
+In the `QuestionAnsweringFromMemoryQuery` function of the `QuestionAnsweringPlugin`, null is no longer returned when there are no relevant memory results. Instead, the execution flow continues, prompting a message with an empty context information, ultimately resulting in a response such as "I don't know" or a similar message.
+
+### Minor Changes
+- Changes in the prompt of `QuestionAnsweringPlugin` to enhance language detection in the response.
+
 ## [8.1.4]
 
 ### Major Changes

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>8.1.4</VersionPrefix>
+    <VersionPrefix>8.1.5-preview-01</VersionPrefix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Plugins/QuestionAnsweringPlugin.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Plugins/QuestionAnsweringPlugin.cs
@@ -122,12 +122,6 @@ public class QuestionAnsweringPlugin
 
         var memoryQueryResult = memoryQueryFunctionResult.GetValue<string>();
 
-        // If the «QueryMemory» function from the «MemoryQueryPlugin» does not return any result, there is no point in trying to answering the question. In such a case, `null` is returned.
-        if (string.IsNullOrWhiteSpace(memoryQueryResult))
-        {
-            return null;
-        }
-
         // Return to the context of the response function and set the result of the memory query.
         var questionAnsweringVariables = new KernelArguments()
         {

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Plugins/QuestionAnsweringPlugin.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Plugins/QuestionAnsweringPlugin.cs
@@ -15,22 +15,34 @@ public class QuestionAnsweringPlugin
 {
     private const string QuestionAnsweringFromContextFunctionPrompt = @"
 [CONTEXT]
+
 {{$context}}
 
+[END CONTEXT]
+
 [INSTRUCTIONS]
-You ANSWER questions with information from the CONTEXT.
-ONLY USE information from CONTEXT.
-The ANSWER MUST BE ALWAYS in {{$locale}}. 
-If you are unable to find the answer or do not know it, simply say ""I don't know"". 
-The ""I don't know"" response MUST BE TRANSLATED ALWAYS to {{$locale}}. 
-If presented with a logic question about the CONTEXT, attempt to calculate the answer. 
-ALWAYS RESPOND with a FINAL ANSWER, DO NOT CONTINUE the conversation.
+
+1. You ANSWER questions with information from the [CONTEXT].
+2. ONLY USE information from [CONTEXT].
+3. If you are unable to find the answer or do not know it, simply say ""I don't know"". 
+4. The ""I don't know"" response MUST BE TRANSLATED ALWAYS to {{$locale}}. 
+5. If presented with a logic question about the [CONTEXT], attempt to calculate the answer. 
+6. ALWAYS RESPOND with a FINAL ANSWER, DO NOT CONTINUE the conversation.
+7. The [ANSWER] MUST BE ALWAYS in {{$locale}}.
+
+[END INSTRUCTIONS]
 
 [QUESTION]
+
 {{$input}}
 
+[END QUESTION]
+
 [IMPORTANT]
-Remember, your ANSWER MUST ALWAYS BE in {{$locale}}.
+
+- Remember, your [ANSWER] MUST ALWAYS BE in {{$locale}}.
+
+[END IMPORTANT]
 
 [ANSWER]
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Plugins/QuestionAnsweringPlugin.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Plugins/QuestionAnsweringPlugin.cs
@@ -14,19 +14,23 @@ namespace Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.Plugins;
 public class QuestionAnsweringPlugin
 {
     private const string QuestionAnsweringFromContextFunctionPrompt = @"
+[CONTEXT]
+{{$context}}
+
+[INSTRUCTIONS]
 You ANSWER questions with information from the CONTEXT.
-ONLY USE information from CONTEXT
+ONLY USE information from CONTEXT.
 The ANSWER MUST BE ALWAYS in {{$locale}}. 
 If you are unable to find the answer or do not know it, simply say ""I don't know"". 
 The ""I don't know"" response MUST BE TRANSLATED ALWAYS to {{$locale}}. 
 If presented with a logic question about the CONTEXT, attempt to calculate the answer. 
 ALWAYS RESPOND with a FINAL ANSWER, DO NOT CONTINUE the conversation.
 
-[CONTEXT]
-{{$context}}
-
 [QUESTION]
 {{$input}}
+
+[IMPORTANT]
+Remember, your ANSWER MUST ALWAYS BE in {{$locale}}.
 
 [ANSWER]
 
@@ -157,7 +161,7 @@ ALWAYS RESPOND with a FINAL ANSWER, DO NOT CONTINUE the conversation.
     {
         return string.IsNullOrWhiteSpace(locale)
             ? "the SAME LANGUAGE as the QUESTION"
-            : $"{locale} LANGUAGE";
+            : $"\"{locale}\" LANGUAGE";
     }
 
     private Task<int> GetQuestionAnsweringFromContextFunctionUsedTokensAsync(KernelFunction questionAnsweringFromContextFunction, string input, string locale, CancellationToken cancellationToken)


### PR DESCRIPTION
- Updated the prompt in `QuestionAnsweringPlugin` to improve language detection in the response.
- In the `QuestionAnsweringPlugin`'s `QuestionAnsweringFromMemoryQuery` function, the previous behavior of returning `null` when no relevant memory results are found has been refactored. Now, the execution flow continues, generating a prompt with an empty context. This adjustment results in a response such as "I don't know" or a similar message.
