### PR TITLE
Updated dependencies:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,28 @@ Previous classification is not required if changes are simple or all belong to t
 ### Breaking Changes 
 In the `QuestionAnsweringFromMemoryQuery` function of the `QuestionAnsweringPlugin`, null is no longer returned when there are no relevant memory results. Instead, the execution flow continues, prompting a message with an empty context information, ultimately resulting in a response such as "I don't know" or a similar message.
 
+### Major Changes
+- Updated dependencies:
+  - Updated `Azure.Core` from `1.37.0` to `1.38.0`.
+  - Updated `Microsoft.Bot.Builder.Azure` from `4.22.1` to `4.22.2`.
+  - Updated `Microsoft.Bot.Builder.Azure.Blobs` from `4.22.1` to `4.22.2`.
+  - Updated `Microsoft.Bot.Builder.Dialogs` from `4.22.1` to `4.22.2`.
+  - Updated `Microsoft.Bot.Builder.Integration.ApplicationInsights.Core` from `4.22.1` to `4.22.2`.
+  - Updated `MMicrosoft.Bot.Builder.Integration.AspNet.Core` from `4.22.1` to `4.22.2`.
+  - Updated `Microsoft.SemanticKernel.Abstractions` from `1.4.0` to `1.5.0`.
+  - Updated `Microsoft.SemanticKernel.Connectors.AzureAISearch` from `1.4.0-alpha` to `1.5.0-alpha`. This does fix the [Issue 72](https://github.com/Encamina/enmarcha/issues/72).
+  - Updated `Microsoft.SemanticKernel.Connectors.OpenAI` from `1.4.0` to `1.5.0`.
+  - Updated `Microsoft.SemanticKernel.Connectors.Qdrant` from `1.4.0-alpha` to `1.5.0-alpha`.
+  - Updated `Microsoft.SemanticKernel.Core` from `1.4.0` to `1.5.0`.
+  - Updated `Microsoft.SemanticKernel.Plugins.Document` from `1.4.0-alpha` to `1.5.0-alpha`.
+  - Updated `Microsoft.SemanticKernel.Plugins.Memory` from `1.4.0-alpha` to `1.5.0-alpha`.
+  - Updated `SharpToken` from `1.2.15` to `1.2.17`.
+  - Updated `coverlet.collector` from `6.0.0` to `6.0.1`.
+  - Updated `xunit` from `2.6.6` to `2.7.0`.
+  - Updated `xunit.analyzers` from `1.10.0` to `1.11.0`.
+  - Updated `xunit.extensibility.core` from `2.6.6` to `2.7.0`.
+  - Updated `xunit.runner.visualstudio` from `2.5.6` to `2.5.7`.
+
 ### Minor Changes
 - Changes in the prompt of `QuestionAnsweringPlugin` to enhance language detection in the response.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>8.1.5-preview-01</VersionPrefix>
+    <VersionPrefix>8.1.5</VersionPrefix>
+    <VersionSuffix>preview-02</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering.csproj
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.4.0-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.5.0-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Encamina.Enmarcha.AI.IntentsPrediction.Azure/Encamina.Enmarcha.AI.IntentsPrediction.Azure.csproj
+++ b/src/Encamina.Enmarcha.AI.IntentsPrediction.Azure/Encamina.Enmarcha.AI.IntentsPrediction.Azure.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Azure.AI.Language.Conversations" Version="1.1.0" />
-        <PackageReference Include="Azure.Core" Version="1.37.0" />
+        <PackageReference Include="Azure.Core" Version="1.38.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
@@ -23,6 +23,6 @@
     </ItemGroup>
     
     <ItemGroup>
-        <None Include="README.md" Pack="true" PackagePath="\"/>
+        <None Include="README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 </Project>

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Encamina.Enmarcha.Bot.Abstractions.csproj
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Encamina.Enmarcha.Bot.Abstractions.csproj
@@ -10,8 +10,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.1" />
-        <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.1" />
+        <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.2" />
+        <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.Bot/Encamina.Enmarcha.Bot.csproj
+++ b/src/Encamina.Enmarcha.Bot/Encamina.Enmarcha.Bot.csproj
@@ -22,11 +22,11 @@
           <TreatAsUsed>true</TreatAsUsed>
           <!-- This project needs this package reference to fix warning NU1701 -->
         </PackageReference>
-        <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.22.1" />
-        <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.22.1" />
-        <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.1" />
-        <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.22.1" />
-        <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.1" />
+        <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.22.2" />
+        <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.22.2" />
+        <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.2" />
+        <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.22.2" />
+        <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.2" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
@@ -17,9 +17,9 @@
     </PropertyGroup>
 
     <ItemGroup>        
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.4.0" PrivateAssets="none" />
-        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.4.0" />
-        <PackageReference Include="SharpToken" Version="1.2.15" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.5.0" PrivateAssets="none" />
+        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.5.0" />
+        <PackageReference Include="SharpToken" Version="1.2.17" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.4.0-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.5.0-alpha" />
     <PackageReference Include="PdfPig" Version="0.1.8" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Memory/Encamina.Enmarcha.SemanticKernel.Connectors.Memory.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Memory/Encamina.Enmarcha.SemanticKernel.Connectors.Memory.csproj
@@ -21,8 +21,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.4.0-alpha" />
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.4.0-alpha" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.5.0-alpha" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.5.0-alpha" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.4.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.4.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.5.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.4.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tst/Directory.Build.targets
+++ b/tst/Directory.Build.targets
@@ -8,16 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>   
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />    
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.analyzers" Version="1.10.0" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.analyzers" Version="1.11.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
  - Updated `Azure.Core` from `1.37.0` to `1.38.0`.
  - Updated `Microsoft.Bot.Builder.Azure` from `4.22.1` to `4.22.2`.
  - Updated `Microsoft.Bot.Builder.Azure.Blobs` from `4.22.1` to `4.22.2`.
  - Updated `Microsoft.Bot.Builder.Dialogs` from `4.22.1` to `4.22.2`.
  - Updated `Microsoft.Bot.Builder.Integration.ApplicationInsights.Core` from `4.22.1` to `4.22.2`.
  - Updated `MMicrosoft.Bot.Builder.Integration.AspNet.Core` from `4.22.1` to `4.22.2`.
  - Updated `Microsoft.SemanticKernel.Abstractions` from `1.4.0` to `1.5.0`.
  - Updated `Microsoft.SemanticKernel.Connectors.AzureAISearch` from `1.4.0-alpha` to `1.5.0-alpha`. This does fix the [Issue 72](https://github.com/Encamina/enmarcha/issues/72).
  - Updated `Microsoft.SemanticKernel.Connectors.OpenAI` from `1.4.0` to `1.5.0`.
  - Updated `Microsoft.SemanticKernel.Connectors.Qdrant` from `1.4.0-alpha` to `1.5.0-alpha`.
  - Updated `Microsoft.SemanticKernel.Core` from `1.4.0` to `1.5.0`.
  - Updated `Microsoft.SemanticKernel.Plugins.Document` from `1.4.0-alpha` to `1.5.0-alpha`.
  - Updated `Microsoft.SemanticKernel.Plugins.Memory` from `1.4.0-alpha` to `1.5.0-alpha`.
  - Updated `SharpToken` from `1.2.15` to `1.2.17`.
  - Updated `coverlet.collector` from `6.0.0` to `6.0.1`.
  - Updated `xunit` from `2.6.6` to `2.7.0`.
  - Updated `xunit.analyzers` from `1.10.0` to `1.11.0`.
  - Updated `xunit.extensibility.core` from `2.6.6` to `2.7.0`.
  - Updated `xunit.runner.visualstudio` from `2.5.6` to `2.5.7`.