### PR TITLE
Updated dependencies and added feature to delete chat history messages from `ChatHistoryProvider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Previous classification is not required if changes are simple or all belong to t
 
 ### Breaking Changes 
 
- - In `AzureOpenAIOptions` the default value of `ServiceVersion` changes from `V2023_12_01_Preview` to `V2023_05_15` since the former is **deprecated**.
+ - In `AzureOpenAIOptions` the default value of `ServiceVersion` changes from `V2023_12_01_Preview` to `V2024_02_15_Preview` since the former is **deprecated**.
  - In the `QuestionAnsweringFromMemoryQuery` function of the `QuestionAnsweringPlugin`, a `null` value is no longer returned when there are no relevant memory results. Instead, the execution flow continues, prompting a message with an empty context information, ultimately resulting in a response such as "I don't know" or a similar message.
 
 ### Major Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,19 @@ Previous classification is not required if changes are simple or all belong to t
 ## [8.1.5]
 
 ### Breaking Changes 
-In the `QuestionAnsweringFromMemoryQuery` function of the `QuestionAnsweringPlugin`, null is no longer returned when there are no relevant memory results. Instead, the execution flow continues, prompting a message with an empty context information, ultimately resulting in a response such as "I don't know" or a similar message.
+
+ - In `AzureOpenAIOptions` the default value of `ServiceVersion` changes from `V2023_12_01_Preview` to `V2023_05_15` since the former is **deprecated**.
+ - In the `QuestionAnsweringFromMemoryQuery` function of the `QuestionAnsweringPlugin`, a `null` value is no longer returned when there are no relevant memory results. Instead, the execution flow continues, prompting a message with an empty context information, ultimately resulting in a response such as "I don't know" or a similar message.
 
 ### Major Changes
+
+- In interface type `IChatHistoryProvider` added new method `DeleteChatMessagesHistoryAsync` to delete a user's chat history messages. This method is implemented in `ChatHistoryProvider`.
 - Updated dependencies:
+  - Updated `Bogus` from `35.4.0` to `35.4.1`.
   - Updated `Azure.Core` from `1.37.0` to `1.38.0`.
+  - Updated `Azure.OpenAI` from `1.0.0-beta13` to `1.0.0-beta14`.
+  - Updated `MailKit` from `4.3.0` to `4.4.0`.
+  - Updated `MimeKit` from `4.3.0` to `4.4.0`.
   - Updated `Microsoft.Bot.Builder.Azure` from `4.22.1` to `4.22.2`.
   - Updated `Microsoft.Bot.Builder.Azure.Blobs` from `4.22.1` to `4.22.2`.
   - Updated `Microsoft.Bot.Builder.Dialogs` from `4.22.1` to `4.22.2`.
@@ -44,7 +52,10 @@ In the `QuestionAnsweringFromMemoryQuery` function of the `QuestionAnsweringPlug
   - Updated `xunit.runner.visualstudio` from `2.5.6` to `2.5.7`.
 
 ### Minor Changes
+
 - Changes in the prompt of `QuestionAnsweringPlugin` to enhance language detection in the response.
+- Slight improvement in the `DeleteAsync` method in `CosmosRepository`.
+- Some boy scouting and typo fixes in comments.
 
 ## [8.1.4]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.5</VersionPrefix>
-    <VersionSuffix>preview-02</VersionSuffix>
+    <VersionSuffix>preview-03</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.AI.OpenAI.Azure/AzureOpenAIOptions.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Azure/AzureOpenAIOptions.cs
@@ -16,7 +16,7 @@ public sealed class AzureOpenAIOptions : OpenAIOptions
     /// <summary>
     /// Gets the Azure OpenAI API service version.
     /// </summary>
-    public OpenAIClientOptions.ServiceVersion ServiceVersion { get; init; } = OpenAIClientOptions.ServiceVersion.V2023_05_15;
+    public OpenAIClientOptions.ServiceVersion ServiceVersion { get; init; } = OpenAIClientOptions.ServiceVersion.V2024_02_15_Preview;
 
     /// <summary>
     /// Gets the <see cref="System.Uri "/> for an LLM resource (like OpenAI). This should include protocol and host name.

--- a/src/Encamina.Enmarcha.AI.OpenAI.Azure/AzureOpenAIOptions.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Azure/AzureOpenAIOptions.cs
@@ -16,7 +16,7 @@ public sealed class AzureOpenAIOptions : OpenAIOptions
     /// <summary>
     /// Gets the Azure OpenAI API service version.
     /// </summary>
-    public OpenAIClientOptions.ServiceVersion ServiceVersion { get; init; } = OpenAIClientOptions.ServiceVersion.V2023_12_01_Preview;
+    public OpenAIClientOptions.ServiceVersion ServiceVersion { get; init; } = OpenAIClientOptions.ServiceVersion.V2023_05_15;
 
     /// <summary>
     /// Gets the <see cref="System.Uri "/> for an LLM resource (like OpenAI). This should include protocol and host name.

--- a/src/Encamina.Enmarcha.AI.OpenAI.Azure/Encamina.Enmarcha.AI.OpenAI.Azure.csproj
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Azure/Encamina.Enmarcha.AI.OpenAI.Azure.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.13" />
+        <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.14" />
         <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.2" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />

--- a/src/Encamina.Enmarcha.Data.Abstractions/IAsyncRepository.cs
+++ b/src/Encamina.Enmarcha.Data.Abstractions/IAsyncRepository.cs
@@ -1,11 +1,9 @@
-﻿using Encamina.Enmarcha.Entities.Abstractions;
-
-namespace Encamina.Enmarcha.Data.Abstractions;
+﻿namespace Encamina.Enmarcha.Data.Abstractions;
 
 /// <summary>
-/// Represents an asychronous repository with operations to read and write entities.
+/// Represents an asynchronous repository with operations to read and write entities.
 /// </summary>
-/// <typeparam name="TEntity">The specific type of (data) entity handled by this asychronous repository.</typeparam>
+/// <typeparam name="TEntity">The specific type of (data) entity handled by this asynchronous repository.</typeparam>
 public interface IAsyncRepository<TEntity> : IAsyncReadRepository<TEntity>, IAsyncWriteRepository<TEntity>
 {
 }

--- a/src/Encamina.Enmarcha.Data.Abstractions/IAsyncWriteRepository.cs
+++ b/src/Encamina.Enmarcha.Data.Abstractions/IAsyncWriteRepository.cs
@@ -5,7 +5,7 @@ namespace Encamina.Enmarcha.Data.Abstractions;
 /// <summary>
 /// Represents an asynchronous repository pattern specifically for write operations.
 /// </summary>
-/// <typeparam name="TEntity">The type of (data) entity handled by this asychronous write repository.</typeparam>
+/// <typeparam name="TEntity">The type of (data) entity handled by this asynchronous write repository.</typeparam>
 public interface IAsyncWriteRepository<in TEntity>
 {
     /// <summary>

--- a/src/Encamina.Enmarcha.Data.Cosmos/CosmosRepository{T}.cs
+++ b/src/Encamina.Enmarcha.Data.Cosmos/CosmosRepository{T}.cs
@@ -317,7 +317,7 @@ internal sealed class CosmosRepository<T> : ICosmosRepository<T>
     public async Task AddBatchAsync(IEnumerable<T> entities, CancellationToken cancellationToken) => await AddOrUpdateBulkAsync(entities, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task DeleteAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken) => await DeleteAsync(id.ToString(), null, cancellationToken);
+    public async Task DeleteAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken) => await DeleteAsync(id is string idString ? idString : id.ToString(), null, cancellationToken);
 
     private static async Task<(IQueryable<TEntity> Results, string ContinuationToken)> BuildResult<TEntity>(FeedIterator<TEntity> feedIterator, CancellationToken cancellationToken)
     {

--- a/src/Encamina.Enmarcha.Email.MailKit/Encamina.Enmarcha.Email.MailKit.csproj
+++ b/src/Encamina.Enmarcha.Email.MailKit/Encamina.Enmarcha.Email.MailKit.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MailKit" Version="4.3.0" />
+        <PackageReference Include="MailKit" Version="4.4.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="README.md" Pack="true" PackagePath="\"/>
+        <None Include="README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IChatHistoryProvider.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IChatHistoryProvider.cs
@@ -8,6 +8,14 @@ namespace Encamina.Enmarcha.SemanticKernel.Abstractions;
 public interface IChatHistoryProvider
 {
     /// <summary>
+    /// Deletes all chat history messages for a specific user.
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user that is owner of the chat.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
+    /// <returns>A <see cref="Task"/> that on completion indicates the asynchronous operation has executed.</returns>
+    Task DeleteChatMessagesHistoryAsync(string userId, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Loads chat history messages.
     /// </summary>
     /// <param name="chatHistory">The current chat history.</param>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/ChatHistoryProvider.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/ChatHistoryProvider.cs
@@ -34,6 +34,12 @@ public class ChatHistoryProvider : IChatHistoryProvider
     }
 
     /// <inheritdoc/>
+    public async Task DeleteChatMessagesHistoryAsync(string userId, CancellationToken cancellationToken)
+    {
+        await chatMessagesHistoryRepository.DeleteAsync(userId, cancellationToken);
+    }
+
+    /// <inheritdoc/>
     /// <remarks>
     /// The maximum number of messages to load is configured in <c>ChatHistoryProviderOptions.HistoryMaxMessages</c>.
     /// </remarks>

--- a/src/Encamina.Enmarcha.Testing.Smtp/Encamina.Enmarcha.Testing.Smtp.csproj
+++ b/src/Encamina.Enmarcha.Testing.Smtp/Encamina.Enmarcha.Testing.Smtp.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageReference Include="MimeKit" Version="4.3.0" />
+    <PackageReference Include="MimeKit" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,7 +18,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Encamina.Enmarcha.Testing/Encamina.Enmarcha.Testing.csproj
+++ b/src/Encamina.Enmarcha.Testing/Encamina.Enmarcha.Testing.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Bogus" Version="35.4.0" />
+    <PackageReference Include="Bogus" Version="35.4.1" />
   </ItemGroup>
     
   <ItemGroup>


### PR DESCRIPTION
- In `AzureOpenAIOptions` the default value of `ServiceVersion` changes from `V2023_12_01_Preview` to `V2024_02_15_Preview` since the former is **deprecated**.
- In interface type `IChatHistoryProvider` added new method `DeleteChatMessagesHistoryAsync` to delete a user's chat history messages. This method is implemented in `ChatHistoryProvider`.
- Slight improvement in the `DeleteAsync` method in `CosmosRepository`.
- Some boy scouting and typo fixes in comments.
- Updated dependencies:
  - Updated `Bogus` from `35.4.0` to `35.4.1`.
  - Updated `Azure.Core` from `1.37.0` to `1.38.0`.
  - Updated `Azure.OpenAI` from `1.0.0-beta13` to `1.0.0-beta14`.
  - Updated `MailKit` from `4.3.0` to `4.4.0`.
  - Updated `MimeKit` from `4.3.0` to `4.4.0`.