### PR TITLE
Improved SemanticTextSplitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Previous classification is not required if changes are simple or all belong to t
 - Fixed `DeleteAsync<TEntityId>` method in `CosmosRepository<T>`. This method was always throwing exceptions because the partition key value was always `null`. It is fixed by considering the `Id` to delete the whole partition. If a specific item in the partition should be removed, then use the `DeleteAsync` on-generic method.
 - Added `DefaultDocumentContentSemanticExtractor` to retrieve semantic chunks from documents.
 - Bug fix in the `MathUtils.Quartiles` method.
+- Enhanced `SplitAsync` in `Encamina.Enmarcha.AI.SemanticTextSplitter` to iteratively split chunks exceeding `options.MaxChunkSize` with a retry limit of `options.ChunkSplitRetryLimit`.
 - Updated dependencies:
   - Updated `Bogus` from `35.4.0` to `35.4.1`.
   - Updated `Azure.Core` from `1.37.0` to `1.38.0`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.5</VersionPrefix>
-    <VersionSuffix>preview-08</VersionSuffix>
+    <VersionSuffix>preview-09</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.AI.Abstractions/SemanticTextSplitterOptions.cs
+++ b/src/Encamina.Enmarcha.AI.Abstractions/SemanticTextSplitterOptions.cs
@@ -38,4 +38,17 @@ public class SemanticTextSplitterOptions
     /// </remarks>
     [Required]
     public float BreakpointThresholdAmount { get; init; } = 95;
+
+    /// <summary>
+    /// Gets maximum allowed size for each chunk. If specified, the text will be split into chunks with a maximum size as defined by this property.
+    /// </summary>
+    [Range(0, int.MaxValue)]
+    public int? MaxChunkSize { get; init; }
+
+    /// <summary>
+    /// Gets maximum number of attempts to split a chunk if its length exceeds the defined maximum chunk size.
+    /// If specified, the splitter will make multiple attempts to split the chunk while respecting the size limit.
+    /// </summary>
+    [Range(0, int.MaxValue)]
+    public int? ChunkSplitRetryLimit { get; init; }
 }

--- a/tst/Encamina.Enmarcha.AI.Tests/SemanticTextSplitterTests.cs
+++ b/tst/Encamina.Enmarcha.AI.Tests/SemanticTextSplitterTests.cs
@@ -17,7 +17,7 @@ public sealed class SemanticTextSplitterTests
         const string text = "This is a text that has 5 sentences. This one here is the second. This is the third. Here we have the fourth! And finally, the last one";
         var semanticTextSplitterOptions = GivenASemanticTextSplitterOptions();
         var optionsMonitor = new TestOptionsMonitor<SemanticTextSplitterOptions>(semanticTextSplitterOptions);
-        var semanticTextSplitter = new SemanticTextSplitter(optionsMonitor);
+        var semanticTextSplitter = new SemanticTextSplitter(optionsMonitor, ILengthFunctions.LengthByCharacterCount);
 
         embeddingsGeneratorMock
             .Setup(generator => generator(It.Is<IList<string>>(data => data.SequenceEqual(new[] { "This is a text that has 5 sentences.", "This one here is the second.", "This is the third.", "Here we have the fourth!", "And finally, the last one" })), It.IsAny<CancellationToken>()))
@@ -28,7 +28,6 @@ public sealed class SemanticTextSplitterTests
                 new([25.0f, 8.0f]),
                 new([3.0f, 1.0f]),
                 new([7.0f, 1.0f]),
-                new([10.0f, 4.0f]),
             });
 
         // Act...
@@ -41,13 +40,50 @@ public sealed class SemanticTextSplitterTests
     }
 
     [Fact]
+    public async Task SplitText_With_MaxChunkSizeAndRetryLimit_Succeeds()
+    {
+        // Arrange...
+        const string text = "This is a text that has 4 sentences. This is the second sentence. Third. Here we have the last one!";
+        var semanticTextSplitterOptions = GivenASemanticTextSplitterOptions(maxChunkSize: 50, chunkSplitRetryLimit: 1);
+        var optionsMonitor = new TestOptionsMonitor<SemanticTextSplitterOptions>(semanticTextSplitterOptions);
+        var semanticTextSplitter = new SemanticTextSplitter(optionsMonitor, ILengthFunctions.LengthByCharacterCount);
+
+        embeddingsGeneratorMock
+            .Setup(generator => generator(It.Is<IList<string>>(data => data.SequenceEqual(new[] { "This is a text that has 4 sentences.", "This is the second sentence.", "Third.", "Here we have the last one!" })), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ReadOnlyMemory<float>>(3)
+            {
+                new([99999999.0f, 98100f]), // This represents that the first sentence is very different
+                new([2.0f, 1.0f]),
+                new([25.0f, 8.0f]),
+            });
+
+        embeddingsGeneratorMock
+            .Setup(generator => generator(It.Is<IList<string>>(data => data.SequenceEqual(new[] { "This is the second sentence.", "Third.", "Here we have the last one!" })), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ReadOnlyMemory<float>>(3)
+            {
+                new([99999999.0f, 98100f]), // This represents that the first sentence is very different
+                new([2.0f, 1.0f]),
+                new([25.0f, 8.0f]),
+            });
+
+        // Act...
+        var splits = (await semanticTextSplitter.SplitAsync(text, embeddingsGeneratorMock.Object, CancellationToken.None)).ToList();
+
+        // Assert...
+        Assert.Equal(3, splits.Count);
+        Assert.Equal("This is a text that has 4 sentences.", splits[0]);
+        Assert.Equal("This is the second sentence.", splits[1]);
+        Assert.Equal("Third. Here we have the last one!", splits[2]);
+    }
+
+    [Fact]
     public async Task SplitText_With_SingleSentence_Returns_OriginalText()
     {
         // Arrange...
         const string singleSentence = "This is a single sentence.";
         var semanticTextSplitterOptions = GivenASemanticTextSplitterOptions();
         var optionsMonitor = new TestOptionsMonitor<SemanticTextSplitterOptions>(semanticTextSplitterOptions);
-        var semanticTextSplitter = new SemanticTextSplitter(optionsMonitor);
+        var semanticTextSplitter = new SemanticTextSplitter(optionsMonitor, ILengthFunctions.LengthByCharacterCount);
 
         // Act...
         var splits = (await semanticTextSplitter.SplitAsync(singleSentence, embeddingsGeneratorMock.Object, CancellationToken.None)).ToList();
@@ -57,13 +93,15 @@ public sealed class SemanticTextSplitterTests
         Assert.Equal(singleSentence, splits[0]);
     }
 
-    private static SemanticTextSplitterOptions GivenASemanticTextSplitterOptions()
+    private static SemanticTextSplitterOptions GivenASemanticTextSplitterOptions(int? maxChunkSize = null, int? chunkSplitRetryLimit = null)
     {
         return new SemanticTextSplitterOptions()
         {
             BufferSize = 0,
             BreakpointThresholdAmount = 95,
             BreakpointThresholdType = BreakpointThresholdType.Percentile,
+            MaxChunkSize = maxChunkSize,
+            ChunkSplitRetryLimit = chunkSplitRetryLimit,
         };
     }
 }


### PR DESCRIPTION
Improved the `SplitAsync` method in `Encamina.Enmarcha.AI.SemanticTextSplitter` to iteratively split oversized chunks with a retry limit. This modification improves the handling of text chunks exceeding `options.MaxChunkSize` by introducing iterative splitting with a retry limit of `options.ChunkSplitRetryLimit`.