### PR TITLE
Update Semantic Kernel to 1.6.2 to fix issue with `JsonSchema.Net.Generation` package to resolve dependency conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,13 +46,13 @@ Previous classification is not required if changes are simple or all belong to t
   - Updated `Microsoft.Bot.Builder.Dialogs` from `4.22.1` to `4.22.2`.
   - Updated `Microsoft.Bot.Builder.Integration.ApplicationInsights.Core` from `4.22.1` to `4.22.2`.
   - Updated `MMicrosoft.Bot.Builder.Integration.AspNet.Core` from `4.22.1` to `4.22.2`.
-  - Updated `Microsoft.SemanticKernel.Abstractions` from `1.4.0` to `1.6.1`.
-  - Updated `Microsoft.SemanticKernel.Connectors.AzureAISearch` from `1.4.0-alpha` to `1.6.1-alpha`. This does fix the [Issue 72](https://github.com/Encamina/enmarcha/issues/72).
-  - Updated `Microsoft.SemanticKernel.Connectors.OpenAI` from `1.4.0` to `1.6.1`.
-  - Updated `Microsoft.SemanticKernel.Connectors.Qdrant` from `1.4.0-alpha` to `1.6.1-alpha`.
-  - Updated `Microsoft.SemanticKernel.Core` from `1.4.0` to `1.6.1`.
-  - Updated `Microsoft.SemanticKernel.Plugins.Document` from `1.4.0-alpha` to `1.6.1-alpha`.
-  - Updated `Microsoft.SemanticKernel.Plugins.Memory` from `1.4.0-alpha` to `1.6.1-alpha`.
+  - Updated `Microsoft.SemanticKernel.Abstractions` from `1.4.0` to `1.6.2`.
+  - Updated `Microsoft.SemanticKernel.Connectors.AzureAISearch` from `1.4.0-alpha` to `1.6.2-alpha`. This does fix the [Issue 72](https://github.com/Encamina/enmarcha/issues/72).
+  - Updated `Microsoft.SemanticKernel.Connectors.OpenAI` from `1.4.0` to `1.6.2`.
+  - Updated `Microsoft.SemanticKernel.Connectors.Qdrant` from `1.4.0-alpha` to `1.6.2-alpha`.
+  - Updated `Microsoft.SemanticKernel.Core` from `1.4.0` to `1.6.2`.
+  - Updated `Microsoft.SemanticKernel.Plugins.Document` from `1.4.0-alpha` to `1.6.2-alpha`.
+  - Updated `Microsoft.SemanticKernel.Plugins.Memory` from `1.4.0-alpha` to `1.6.2-alpha`.
   - Updated `SharpToken` from `1.2.15` to `1.2.17`.
   - Updated `coverlet.collector` from `6.0.0` to `6.0.1`.
   - Updated `xunit` from `2.6.6` to `2.7.0`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.5</VersionPrefix>
-    <VersionSuffix>preview-12</VersionSuffix>
+    <VersionSuffix>preview-13</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering.csproj
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.6.1-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.6.2-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
@@ -17,8 +17,8 @@
     </PropertyGroup>
 
     <ItemGroup>        
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.6.1" PrivateAssets="none" />
-        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.6.1" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.6.2" PrivateAssets="none" />
+        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.6.2" />
         <PackageReference Include="SharpToken" Version="1.2.17" />
     </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.6.1-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.6.2-alpha" />
     <PackageReference Include="PdfPig" Version="0.1.8" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Memory/Encamina.Enmarcha.SemanticKernel.Connectors.Memory.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Memory/Encamina.Enmarcha.SemanticKernel.Connectors.Memory.csproj
@@ -21,8 +21,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.6.1-alpha" />
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.6.1-alpha" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.6.2-alpha" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.6.2-alpha" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.6.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.6.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.6.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.6.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.6.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.6.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update Semantic Kernel to 1.6.2 to fix issue with `JsonSchema.Net.Generation` package to resolve dependency conflict.