### PR TITLE
Change some access modifiers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.5</VersionPrefix>
-    <VersionSuffix>preview-13</VersionSuffix>
+    <VersionSuffix>preview-14</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Bot/Controllers/BotBaseController.cs
+++ b/src/Encamina.Enmarcha.Bot/Controllers/BotBaseController.cs
@@ -36,6 +36,9 @@ public abstract class BotBaseController : ControllerBase
     /// <summary>
     /// Handles a request for the bot.
     /// </summary>
+    /// <remarks>
+    /// This method does not uses a `CancellationToken` because Azure Bot Service would cancel the request if it did not receive a response within 15 seconds.
+    /// </remarks>
     /// <returns>
     /// A <see cref="Task"/> that represents the asynchronous operation of handling the request for the bot.
     /// </returns>

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/StrictFormatCleanPdfDocumentConnector.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/StrictFormatCleanPdfDocumentConnector.cs
@@ -51,7 +51,12 @@ public class StrictFormatCleanPdfDocumentConnector : CleanPdfDocumentConnector
         return sb.ToString();
     }
 
-    private static IEnumerable<TextBlock> GetTextBlocks(Page page)
+    /// <summary>
+    /// Extracts <see cref="TextBlock"/> from a given page of a PDF document.
+    /// </summary>
+    /// <param name="page">The page from which to extract text blocks.</param>
+    /// <returns>An enumerable collection of <see cref="TextBlock" /> extracted from the page.</returns>
+    protected static IEnumerable<TextBlock> GetTextBlocks(Page page)
     {
         // 1. Extract words
         var words = NearestNeighbourWordExtractor.Instance.GetWords(page.Letters);
@@ -70,7 +75,13 @@ public class StrictFormatCleanPdfDocumentConnector : CleanPdfDocumentConnector
         return orderedTextBlocks;
     }
 
-    private static IEnumerable<TextBlock> CleanTextBlocks(PdfDocument document, IEnumerable<TextBlock> textBlocks)
+    /// <summary>
+    /// Cleans the extracted text blocks from a PDF document by removing common words that overlap across pages and excluding non-horizontal text.
+    /// </summary>
+    /// <param name="document">The PDF document.</param>
+    /// <param name="textBlocks">The extracted text blocks.</param>
+    /// <returns>The cleaned text blocks.</returns>
+    protected static IEnumerable<TextBlock> CleanTextBlocks(PdfDocument document, IEnumerable<TextBlock> textBlocks)
     {
         var horizontalTextBlocks = textBlocks
             .Where(tb => tb.TextOrientation == TextOrientation.Horizontal)

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/IDocumentConnectorUtils.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/IDocumentConnectorUtils.cs
@@ -12,7 +12,7 @@ namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document;
 /// <summary>
 /// Utility class providing methods for working with document connectors.
 /// </summary>
-internal static class IDocumentConnectorUtils
+public static class IDocumentConnectorUtils
 {
     /// <summary>
     /// Gets the default document connector based on the specified file extension.
@@ -20,7 +20,7 @@ internal static class IDocumentConnectorUtils
     /// <param name="fileExtension">The file extension for which to retrieve the connector.</param>
     /// <returns>An instance of the default document connector for the specified file extension.</returns>
     /// <exception cref="NotSupportedException">Thrown when the file extension is not supported.</exception>
-    internal static IDocumentConnector GetDefaultDocumentConnector(string fileExtension)
+    public static IDocumentConnector GetDefaultDocumentConnector(string fileExtension)
     {
         return fileExtension.ToUpperInvariant() switch
         {


### PR DESCRIPTION
- Modify some `StrictFormatCleanPdfDocumentConnector` access modifiers to facilitate the inheritance
- Make `IDocumentConnectorUtils` public to allow use the utils outside the library