### PR TITLE
Add possibility of be able to manage the chat history with a value different from UserId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ Also, any bug fix must start with the prefix �Bug fix:� followed by the desc
 
 Previous classification is not required if changes are simple or all belong to the same category.
 
+## [8.1.6]
 
+### Breaking Changes 
+
+ - Renamed `UserId` to `IndexerId` in `ChatMessageHistoryRecord`. This change requires consumers to update their database to match the new property name. 
+    - In case of using Cosmos DB, `IndexerId` should be the new partition key of the collection. You can learn how to change the partition key and do the data migration [here](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/change-partition-key).
 
 ## [8.1.5]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>8.1.5</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>8.1.6</VersionPrefix>
+    <VersionSuffix>preview-01</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IChatHistoryProvider.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IChatHistoryProvider.cs
@@ -10,28 +10,28 @@ public interface IChatHistoryProvider
     /// <summary>
     /// Deletes all chat history messages for a specific user.
     /// </summary>
-    /// <param name="userId">The unique identifier of the user that is owner of the chat.</param>
+    /// <param name="indexerId">The unique identifier of the chat history indexer.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>A <see cref="Task"/> that on completion indicates the asynchronous operation has executed.</returns>
-    Task DeleteChatMessagesHistoryAsync(string userId, CancellationToken cancellationToken);
+    Task DeleteChatMessagesHistoryAsync(string indexerId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Loads chat history messages.
     /// </summary>
     /// <param name="chatHistory">The current chat history.</param>
-    /// <param name="userId">The unique identifier of the user that is owner of the chat.</param>
+    /// <param name="indexerId">The unique identifier of the chat history indexer.</param>
     /// <param name="remainingTokens">The total remaining tokens available for loading messages from the chat history.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>A <see cref="Task"/> that on completion indicates the asynchronous operation has executed.</returns>
-    Task LoadChatMessagesHistoryAsync(ChatHistory chatHistory, string userId, int remainingTokens, CancellationToken cancellationToken);
+    Task LoadChatMessagesHistoryAsync(ChatHistory chatHistory, string indexerId, int remainingTokens, CancellationToken cancellationToken);
 
     /// <summary>
     /// Saves a chat message into the conversation history.
     /// </summary>
-    /// <param name="userId">The user's unique identifier.</param>
+    /// <param name="indexerId">The unique identifier of the chat history indexer.</param>
     /// <param name="roleName">The name of the role associated with the chat message. For example the `user`, the `assistant` or the `system`.</param>
     /// <param name="message">The message.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>A <see cref="Task"/> that on completion indicates the asynchronous operation has executed.</returns>
-    Task SaveChatMessagesHistoryAsync(string userId, string roleName, string message, CancellationToken cancellationToken);
+    Task SaveChatMessagesHistoryAsync(string indexerId, string roleName, string message, CancellationToken cancellationToken);
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/ChatHistoryProvider.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/ChatHistoryProvider.cs
@@ -34,16 +34,16 @@ public class ChatHistoryProvider : IChatHistoryProvider
     }
 
     /// <inheritdoc/>
-    public Task DeleteChatMessagesHistoryAsync(string userId, CancellationToken cancellationToken)
+    public Task DeleteChatMessagesHistoryAsync(string indexerId, CancellationToken cancellationToken)
     {
-        return chatMessagesHistoryRepository.DeleteAsync(userId, cancellationToken);
+        return chatMessagesHistoryRepository.DeleteAsync(indexerId, cancellationToken);
     }
 
     /// <inheritdoc/>
     /// <remarks>
     /// The maximum number of messages to load is configured in <c>ChatHistoryProviderOptions.HistoryMaxMessages</c>.
     /// </remarks>
-    public async Task LoadChatMessagesHistoryAsync(ChatHistory chatHistory, string userId, int remainingTokens, CancellationToken cancellationToken)
+    public async Task LoadChatMessagesHistoryAsync(ChatHistory chatHistory, string indexerId, int remainingTokens, CancellationToken cancellationToken)
     {
         if (options.HistoryMaxMessages <= 0 || remainingTokens <= 0)
         {
@@ -52,7 +52,7 @@ public class ChatHistoryProvider : IChatHistoryProvider
 
         // Obtain the chat history for the user, ordered by timestamps descending to get the most recent messages first, and then take 'N' messages.
         // This means that the first elements in the list are the most recent or newer messages, and the last elements in the list are the oldest messages.
-        var result = (await chatMessagesHistoryRepository.GetAllAsync(chatMessages => chatMessages.Where(chatMessage => chatMessage.UserId == userId)
+        var result = (await chatMessagesHistoryRepository.GetAllAsync(chatMessages => chatMessages.Where(chatMessage => chatMessage.IndexerId == indexerId)
                                                                                                   .OrderByDescending(chatMessage => chatMessage.TimestampUtc)
                                                                                                   .Take(options.HistoryMaxMessages), cancellationToken)).ToList();
 
@@ -102,12 +102,12 @@ public class ChatHistoryProvider : IChatHistoryProvider
     }
 
     /// <inheritdoc/>
-    public async Task SaveChatMessagesHistoryAsync(string userId, string roleName, string message, CancellationToken cancellationToken)
+    public async Task SaveChatMessagesHistoryAsync(string indexerId, string roleName, string message, CancellationToken cancellationToken)
     {
         await chatMessagesHistoryRepository.AddAsync(new ChatMessageHistoryRecord()
         {
             Id = Guid.NewGuid().ToString(),
-            UserId = userId,
+            IndexerId = indexerId,
             RoleName = roleName,
             Message = message,
             TimestampUtc = DateTime.UtcNow,

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Plugins/ChatMessageHistoryRecord.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Plugins/ChatMessageHistoryRecord.cs
@@ -17,11 +17,14 @@ public class ChatMessageHistoryRecord : IIdentifiable<string>
     public virtual string Id { get; init; }
 
     /// <summary>
-    /// Gets the unique identifier of the user owner of the chat.
+    /// Gets the unique identifier of the chat history indexer.
     /// </summary>
-    [JsonProperty(@"userId")]
-    [JsonPropertyName(@"userId")]
-    public virtual string UserId { get; init; }
+    /// <remarks>
+    /// Identifier that relates several messages. This could be, for example, a conversationId, a userId, or any other relevant identifier.
+    /// </remarks>
+    [JsonProperty(@"indexerId")]
+    [JsonPropertyName(@"indexerId")]
+    public virtual string IndexerId { get; init; }
 
     /// <summary>
     /// Gets the name of the role associated with the chat message.


### PR DESCRIPTION
In the `ChatMessageHistoryRecord` class, the name of the `UserId` property has been changed to `IndexerId`, thus allowing the consumer to choose with which value a conversation will be indexed. (for example ConversationId, UserId, or any relevant ID)

This implies breaking changes as indicated in the changelog.