### PR TITLE
Added token credential options to OpenAIOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Previous classification is not required if changes are simple or all belong to t
 
 - Added `CosineStringSimilarityComparer` in `Encamina.Enmarcha.SemanticKernel` to compare two strings using cosine similarity algorithm.
 - Class `SlidePptxDocumentConnector` is now `public` instead of `internal`.
+- Added `UseAzureActiveDirectoryAuthentication` and `TokenCredentialsOptions` properties in `AzureOpenAIOptions`.
+- Added `RequiredIfAttribute` to validate properties based on the value of another property.
  
 ## [8.1.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Previous classification is not required if changes are simple or all belong to t
 - The method `GetDocumentConnector` from interface type `IDocumentConnectorProvider` now throws `InvalidOperationException` if a connector for the specified file extension is not found.
 - Renamed `UserId` to `IndexerId` in `ChatMessageHistoryRecord`. This change requires consumers to update their database to match the new property name. 
    - In case of using Cosmos DB, `IndexerId` should be the new partition key of the collection. You can learn how to change the partition key and do the data migration [here](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/change-partition-key).
+- Split the `OpenAIOptions` class into two separate classes:
+  - Created a new abstract class `OpenAIOptionsBase` containing common properties related to OpenAI model configuration.
+  - Moved the `Key` property to a new concrete class `OpenAIOptions`.
+  - `AzureOpenAIOptions` no longer inherits from `OpenAIOptions`, but now inherits from `OpenAIOptionsBase`.
 
 ### Major Changes
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.6</VersionPrefix>
-    <VersionSuffix>preview-05</VersionSuffix>
+    <VersionSuffix>preview-06</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/OpenAIOptions.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/OpenAIOptions.cs
@@ -1,91 +1,18 @@
-﻿using Encamina.Enmarcha.Core.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
+
+using Encamina.Enmarcha.Core.DataAnnotations;
 
 namespace Encamina.Enmarcha.AI.OpenAI.Abstractions;
 
 /// <summary>
-/// Base class with options to connect and use an OpenAI service.
+/// Options for configuring access to OpenAI services.
 /// </summary>
-public class OpenAIOptions
+public class OpenAIOptions : OpenAIOptionsBase
 {
     /// <summary>
-    /// Gets the model deployment name on the LLM (for example OpenAI) to use for chat.
-    /// </summary>
-    /// <remarks>
-    /// <b>WARNING</b>: The model deployment name does not necessarily have to be the same as the model name. For example, a model of type `gpt-4` might be called «MyGPT»;
-    /// this means that the value of this property does not necessarily indicate the model implemented behind it. Use property <see cref="ChatModelName"/> to set the model name.
-    /// </remarks>
-    [NotEmptyOrWhitespace]
-    public string ChatModelDeploymentName { get; init; }
-
-    /// <summary>
-    /// Gets the name (sort of a unique identifier) of the model to use for chat.
-    /// </summary>
-    /// <remarks>
-    /// This property is required if property <see cref="ChatModelDeploymentName"/>  is not <see langword="null"/>. It is usually used with the <c>Encamina.Enmarcha.AI.OpenAI.Abstractions.ModelInfo"</c> class
-    /// to get metadata and information about the model. This model name must match the model names from the LLM (like OpenAI), like for example `gpt-4` or `gpt-35-turbo`.
-    /// </remarks>
-    [RequireWhenOtherPropertyNotNull(nameof(ChatModelDeploymentName))]
-    [NotEmptyOrWhitespace]
-    public string ChatModelName { get; init; }
-
-    /// <summary>
-    /// Gets the model deployment name on the LLM (for example OpenAI) to use for completions.
-    /// </summary>
-    /// <remarks>
-    /// <b>WARNING</b>: The model name does not necessarily have to be the same as the model ID. For example, a model of type `text-davinci-003` might be called `MyCompletions`;
-    /// this means that the value of this property does not necessarily indicate the model implemented behind it. Use property <see cref="CompletionsModelName"/> to set the model name.
-    /// </remarks>
-    [NotEmptyOrWhitespace]
-    public string CompletionsModelDeploymentName { get; init; }
-
-    /// <summary>
-    /// Gets the name (sort of a unique identifier) of the model to use for completions.
-    /// </summary>
-    /// <remarks>
-    /// This property is required if property <see cref="CompletionsModelDeploymentName"/> is not <see langword="null"/>. It is usually used with the <c>Encamina.Enmarcha.AI.OpenAI.Abstractions.ModelInfo"</c> class
-    /// to get metadata and information about the model. This model name must match the model names from the LLM (like OpenAI), like for example `gpt-4` or `gpt-35-turbo`.
-    /// </remarks>
-    [RequireWhenOtherPropertyNotNull(nameof(CompletionsModelDeploymentName))]
-    [NotEmptyOrWhitespace]
-    public string CompletionsModelName { get; init; }
-
-    /// <summary>
-    /// Gets the model deployment name on the LLM (for example OpenAI) to use for embeddings.
-    /// </summary>
-    /// <remarks>
-    /// <b>WARNING</b>: The model name does not necessarily have to be the same as the model ID. For example, a model of type `text-embedding-ada-002` might be called `MyEmbeddings`;
-    /// this means that the value of this property does not necessarily indicate the model implemented behind it. Use property <see cref="EmbeddingsModelName"/> to set the model name.
-    /// </remarks>
-    [NotEmptyOrWhitespace]
-    public string EmbeddingsModelDeploymentName { get; init; }
-
-    /// <summary>
-    /// Gets the name (sort of a unique identifier) of the model to use for embeddings.
-    /// </summary>
-    /// <remarks>
-    /// This property is required if property <see cref="EmbeddingsModelDeploymentName"/> is not <see langword="null"/>. It is usually used with the <c>Encamina.Enmarcha.AI.OpenAI.Abstractions.ModelInfo"</c> class
-    /// to get metadata and information about the model. This model name must match the model names from the LLM (like OpenAI), like for example `gpt-4` or `gpt-35-turbo`.
-    /// </remarks>
-    [RequireWhenOtherPropertyNotNull(nameof(EmbeddingsModelDeploymentName))]
-    [NotEmptyOrWhitespace]
-    public string EmbeddingsModelName { get; init; }
-
-    /// <summary>
     /// Gets the key credential used to authenticate to an LLM resource.
-    /// This property is required if property <see cref="UseTokenCredentialAuthentication"/> is <c>false</c>.
     /// </summary>
-    [RequiredIf(nameof(UseTokenCredentialAuthentication), false)]
+    [Required]
     [NotEmptyOrWhitespace]
     public string Key { get; init; }
-
-    /// <summary>
-    /// Gets a value indicating whether Token Credential authentication should be used.
-    /// If set to true, the value of the <see cref="Key"/> property is ignored.
-    /// </summary>
-    public bool UseTokenCredentialAuthentication { get; init; }
-
-    /// <summary>
-    /// Gets or sets the token credentials options to authenticate to an LLM resource.
-    /// </summary>
-    public TokenCredentialsOptions TokenCredentialsOptions { get; set; }
 }

--- a/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/OpenAIOptions.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/OpenAIOptions.cs
@@ -79,13 +79,13 @@ public class OpenAIOptions
     public string Key { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether Token Credential authentication should be used.
+    /// Gets a value indicating whether Token Credential authentication should be used.
     /// If set to true, the value of the <see cref="Key"/> property is ignored.
     /// </summary>
     public bool UseTokenCredentialAuthentication { get; init; }
 
     /// <summary>
-    /// Gets the token credentials options to authenticate to an LLM resource.
+    /// Gets or sets the token credentials options to authenticate to an LLM resource.
     /// </summary>
     public TokenCredentialsOptions TokenCredentialsOptions { get; set; }
 }

--- a/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/OpenAIOptions.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/OpenAIOptions.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-using Encamina.Enmarcha.Core.DataAnnotations;
+﻿using Encamina.Enmarcha.Core.DataAnnotations;
 
 namespace Encamina.Enmarcha.AI.OpenAI.Abstractions;
 
@@ -74,8 +72,20 @@ public class OpenAIOptions
 
     /// <summary>
     /// Gets the key credential used to authenticate to an LLM resource.
+    /// This property is required if property <see cref="UseTokenCredentialAuthentication"/> is <c>false</c>.
     /// </summary>
-    [Required]
+    [RequiredIf(nameof(UseTokenCredentialAuthentication), false)]
     [NotEmptyOrWhitespace]
     public string Key { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Token Credential authentication should be used.
+    /// If set to true, the value of the <see cref="Key"/> property is ignored.
+    /// </summary>
+    public bool UseTokenCredentialAuthentication { get; init; }
+
+    /// <summary>
+    /// Gets the token credentials options to authenticate to an LLM resource.
+    /// </summary>
+    public TokenCredentialsOptions TokenCredentialsOptions { get; set; }
 }

--- a/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/OpenAIOptionsBase.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/OpenAIOptionsBase.cs
@@ -1,0 +1,72 @@
+﻿using Encamina.Enmarcha.Core.DataAnnotations;
+
+namespace Encamina.Enmarcha.AI.OpenAI.Abstractions;
+
+/// <summary>
+/// Base class with options to connect and use an OpenAI service.
+/// </summary>
+public abstract class OpenAIOptionsBase
+{
+    /// <summary>
+    /// Gets the model deployment name on the LLM (for example OpenAI) to use for chat.
+    /// </summary>
+    /// <remarks>
+    /// <b>WARNING</b>: The model deployment name does not necessarily have to be the same as the model name. For example, a model of type `gpt-4` might be called «MyGPT»;
+    /// this means that the value of this property does not necessarily indicate the model implemented behind it. Use property <see cref="ChatModelName"/> to set the model name.
+    /// </remarks>
+    [NotEmptyOrWhitespace]
+    public string ChatModelDeploymentName { get; init; }
+
+    /// <summary>
+    /// Gets the name (sort of a unique identifier) of the model to use for chat.
+    /// </summary>
+    /// <remarks>
+    /// This property is required if property <see cref="ChatModelDeploymentName"/>  is not <see langword="null"/>. It is usually used with the <c>Encamina.Enmarcha.AI.OpenAI.Abstractions.ModelInfo"</c> class
+    /// to get metadata and information about the model. This model name must match the model names from the LLM (like OpenAI), like for example `gpt-4` or `gpt-35-turbo`.
+    /// </remarks>
+    [RequireWhenOtherPropertyNotNull(nameof(ChatModelDeploymentName))]
+    [NotEmptyOrWhitespace]
+    public string ChatModelName { get; init; }
+
+    /// <summary>
+    /// Gets the model deployment name on the LLM (for example OpenAI) to use for completions.
+    /// </summary>
+    /// <remarks>
+    /// <b>WARNING</b>: The model name does not necessarily have to be the same as the model ID. For example, a model of type `text-davinci-003` might be called `MyCompletions`;
+    /// this means that the value of this property does not necessarily indicate the model implemented behind it. Use property <see cref="CompletionsModelName"/> to set the model name.
+    /// </remarks>
+    [NotEmptyOrWhitespace]
+    public string CompletionsModelDeploymentName { get; init; }
+
+    /// <summary>
+    /// Gets the name (sort of a unique identifier) of the model to use for completions.
+    /// </summary>
+    /// <remarks>
+    /// This property is required if property <see cref="CompletionsModelDeploymentName"/> is not <see langword="null"/>. It is usually used with the <c>Encamina.Enmarcha.AI.OpenAI.Abstractions.ModelInfo"</c> class
+    /// to get metadata and information about the model. This model name must match the model names from the LLM (like OpenAI), like for example `gpt-4` or `gpt-35-turbo`.
+    /// </remarks>
+    [RequireWhenOtherPropertyNotNull(nameof(CompletionsModelDeploymentName))]
+    [NotEmptyOrWhitespace]
+    public string CompletionsModelName { get; init; }
+
+    /// <summary>
+    /// Gets the model deployment name on the LLM (for example OpenAI) to use for embeddings.
+    /// </summary>
+    /// <remarks>
+    /// <b>WARNING</b>: The model name does not necessarily have to be the same as the model ID. For example, a model of type `text-embedding-ada-002` might be called `MyEmbeddings`;
+    /// this means that the value of this property does not necessarily indicate the model implemented behind it. Use property <see cref="EmbeddingsModelName"/> to set the model name.
+    /// </remarks>
+    [NotEmptyOrWhitespace]
+    public string EmbeddingsModelDeploymentName { get; init; }
+
+    /// <summary>
+    /// Gets the name (sort of a unique identifier) of the model to use for embeddings.
+    /// </summary>
+    /// <remarks>
+    /// This property is required if property <see cref="EmbeddingsModelDeploymentName"/> is not <see langword="null"/>. It is usually used with the <c>Encamina.Enmarcha.AI.OpenAI.Abstractions.ModelInfo"</c> class
+    /// to get metadata and information about the model. This model name must match the model names from the LLM (like OpenAI), like for example `gpt-4` or `gpt-35-turbo`.
+    /// </remarks>
+    [RequireWhenOtherPropertyNotNull(nameof(EmbeddingsModelDeploymentName))]
+    [NotEmptyOrWhitespace]
+    public string EmbeddingsModelName { get; init; }
+}

--- a/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/OpenAIOptionsBase.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/OpenAIOptionsBase.cs
@@ -5,7 +5,7 @@ namespace Encamina.Enmarcha.AI.OpenAI.Abstractions;
 /// <summary>
 /// Base class with options to connect and use an OpenAI service.
 /// </summary>
-public abstract class OpenAIOptionsBase
+public class OpenAIOptionsBase
 {
     /// <summary>
     /// Gets the model deployment name on the LLM (for example OpenAI) to use for chat.

--- a/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/TokenCredentialsOptions.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/TokenCredentialsOptions.cs
@@ -1,0 +1,32 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+using Encamina.Enmarcha.Core.DataAnnotations;
+
+namespace Encamina.Enmarcha.AI.OpenAI.Abstractions;
+
+/// <summary>
+/// Represents the options for token credentials used in authentication.
+/// </summary>
+public class TokenCredentialsOptions
+{
+    /// <summary>
+    /// Gets or sets the tenant ID.
+    /// </summary>
+    [Required]
+    [NotEmptyOrWhitespace]
+    public string TenantId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client ID.
+    /// </summary>
+    [Required]
+    [NotEmptyOrWhitespace]
+    public string ClientId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client secret.
+    /// </summary>
+    [Required]
+    [NotEmptyOrWhitespace]
+    public string ClientSecret { get; set; }
+}

--- a/src/Encamina.Enmarcha.AI.OpenAI.Azure/AzureOpenAIOptions.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Azure/AzureOpenAIOptions.cs
@@ -40,7 +40,7 @@ public sealed class AzureOpenAIOptions : OpenAIOptionsBase
     public bool UseTokenCredentialAuthentication { get; init; }
 
     /// <summary>
-    /// Gets or sets the token credentials options to authenticate to an LLM resource.
+    /// Gets the token credentials options to authenticate to an LLM resource.
     /// </summary>
     public TokenCredentialsOptions TokenCredentialsOptions { get; init; }
 }

--- a/src/Encamina.Enmarcha.AI.OpenAI.Azure/AzureOpenAIOptions.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Azure/AzureOpenAIOptions.cs
@@ -11,7 +11,7 @@ namespace Encamina.Enmarcha.AI.OpenAI.Azure;
 /// <summary>
 /// Configuration options for Azure OpenAI service connection.
 /// </summary>
-public sealed class AzureOpenAIOptions : OpenAIOptions
+public sealed class AzureOpenAIOptions : OpenAIOptionsBase
 {
     /// <summary>
     /// Gets the Azure OpenAI API service version.
@@ -19,10 +19,28 @@ public sealed class AzureOpenAIOptions : OpenAIOptions
     public OpenAIClientOptions.ServiceVersion ServiceVersion { get; init; } = OpenAIClientOptions.ServiceVersion.V2024_02_15_Preview;
 
     /// <summary>
-    /// Gets the <see cref="System.Uri "/> for an LLM resource (like OpenAI). This should include protocol and host name.
+    /// Gets the <see cref="Uri "/> for an LLM resource (like OpenAI). This should include protocol and host name.
     /// </summary>
     [Required]
     [Uri]
     public Uri Endpoint { get; init; }
-}
 
+    /// <summary>
+    /// Gets the key credential used to authenticate to an LLM resource.
+    /// This property is required if property <see cref="UseTokenCredentialAuthentication"/> is <c>false</c>.
+    /// </summary>
+    [RequiredIf(nameof(UseTokenCredentialAuthentication), false)]
+    [NotEmptyOrWhitespace]
+    public string Key { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether Token Credential authentication should be used.
+    /// If set to true, the value of the <see cref="Key"/> property is ignored.
+    /// </summary>
+    public bool UseTokenCredentialAuthentication { get; init; }
+
+    /// <summary>
+    /// Gets or sets the token credentials options to authenticate to an LLM resource.
+    /// </summary>
+    public TokenCredentialsOptions TokenCredentialsOptions { get; init; }
+}

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/RequiredIfAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/RequiredIfAttribute.cs
@@ -1,0 +1,47 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+using Encamina.Enmarcha.Core.DataAnnotations.Resources;
+using Encamina.Enmarcha.Core.Extensions;
+
+namespace Encamina.Enmarcha.Core.DataAnnotations;
+
+/// <summary>
+/// Specifies that the decorated property is required if a specified condition is met.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class RequiredIfAttribute : ValidationAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequiredIfAttribute"/> class.
+    /// </summary>
+    /// <param name="conditionalPropertyName">The name of the property that represents the condition.</param>
+    /// <param name="conditionalValue">The value that triggers the requirement when the condition is met.</param>
+    public RequiredIfAttribute(string conditionalPropertyName, object conditionalValue)
+    {
+        ConditionalPropertyName = conditionalPropertyName;
+        ConditionalValue = conditionalValue;
+    }
+
+    /// <summary>
+    /// Gets the name of the property that represents the condition.
+    /// </summary>
+    public string ConditionalPropertyName { get; }
+
+    /// <summary>
+    /// Gets the value that triggers the requirement when the condition is met.
+    /// </summary>
+    public object ConditionalValue { get; }
+
+    /// <inheritdoc/>
+    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    {
+        var conditionalValue = validationContext.ObjectInstance
+            .GetType()
+            .GetProperty(ConditionalPropertyName)?
+            .GetValue(validationContext.ObjectInstance, null);
+
+        return Equals(ConditionalValue, conditionalValue) && value == null
+            ? new ValidationResult(ValudationResultMessages.ResourceManager.GetFormattedStringByCurrentCulture(nameof(ValudationResultMessages.ValueIsRequiredIf), validationContext.DisplayName, ConditionalPropertyName, ConditionalValue))
+            : ValidationResult.Success;
+    }
+}

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/Resources/ValudationResultMessages.Designer.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/Resources/ValudationResultMessages.Designer.cs
@@ -79,6 +79,15 @@ namespace Encamina.Enmarcha.Core.DataAnnotations.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value of &apos;{0}&apos; is required when the value of &apos;{1}&apos; is {2}!.
+        /// </summary>
+        internal static string ValueIsRequiredIf {
+            get {
+                return ResourceManager.GetString("ValueIsRequiredIf", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value of &apos;{0}&apos; must be a valid and well formed URI!.
         /// </summary>
         internal static string ValuieIsInvalidUri {

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/Resources/ValudationResultMessages.resx
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/Resources/ValudationResultMessages.resx
@@ -123,6 +123,9 @@
   <data name="ValueIsInvalidGuid" xml:space="preserve">
     <value>The value of '{0}' must be a valid GUID and it must not be the empty GUID (i.e., 00000000-0000-0000-0000-000000000000)!</value>
   </data>
+  <data name="ValueIsRequiredIf" xml:space="preserve">
+    <value>The value of '{0}' is required when the value of '{1}' is {2}!</value>
+  </data>
   <data name="ValuieIsInvalidUri" xml:space="preserve">
     <value>The value of '{0}' must be a valid and well formed URI!</value>
   </data>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Extensions/KernelExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Extensions/KernelExtensions.cs
@@ -45,7 +45,7 @@ public static class KernelExtensions
     /// A function to calculate the length by tokens of the chat messages. These functions are usually available in the «mixin» interface <see cref="ILengthFunctions"/>.
     /// </param>
     /// <returns>A list of all the functions found in this plugin, indexed by function name.</returns>
-    public static KernelPlugin ImportChatWithHistoryPlugin(this Kernel kernel, IServiceProvider serviceProvider, OpenAIOptions openAIOptions, Func<string, int> tokensLengthFunction)
+    public static KernelPlugin ImportChatWithHistoryPlugin(this Kernel kernel, IServiceProvider serviceProvider, OpenAIOptionsBase openAIOptions, Func<string, int> tokensLengthFunction)
     {
         Guard.IsNotNull(serviceProvider);
         Guard.IsNotNull(openAIOptions);

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/KernelExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/KernelExtensions.cs
@@ -25,7 +25,7 @@ public static class KernelExtensions
     /// </param>
     /// <returns>A list of all the functions found in this plugin, indexed by function name.</returns>
     /// <seealso href="https://en.wikipedia.org/wiki/Mixin"/>
-    public static IEnumerable<KernelPlugin> ImportQuestionAnsweringPlugin(this Kernel kernel, OpenAIOptions openAIOptions, Func<string, int> tokensLengthFunction)
+    public static IEnumerable<KernelPlugin> ImportQuestionAnsweringPlugin(this Kernel kernel, OpenAIOptionsBase openAIOptions, Func<string, int> tokensLengthFunction)
     {
         Guard.IsNotNull(openAIOptions);
         Guard.IsNotNull(tokensLengthFunction);
@@ -46,7 +46,7 @@ public static class KernelExtensions
     /// </param>
     /// <returns>A list of all the functions found in this plugin, indexed by function name.</returns>
     /// <seealso href="https://en.wikipedia.org/wiki/Mixin"/>
-    public static IEnumerable<KernelPlugin> ImportQuestionAnsweringPluginWithMemory(this Kernel kernel, OpenAIOptions openAIOptions, ISemanticTextMemory semanticTextMemory, Func<string, int> tokensLengthFunction)
+    public static IEnumerable<KernelPlugin> ImportQuestionAnsweringPluginWithMemory(this Kernel kernel, OpenAIOptionsBase openAIOptions, ISemanticTextMemory semanticTextMemory, Func<string, int> tokensLengthFunction)
     {
         kernel.ImportQuestionAnsweringPlugin(openAIOptions, tokensLengthFunction);
         kernel.ImportMemoryPlugin(semanticTextMemory, tokensLengthFunction);


### PR DESCRIPTION
The option `UseTokenCredentialAuthentication` has been added to `OpenAIOptions`. Additionally, though not required, `TokenCredentialsOptions` has also been included.

What do we achieve with this? Until now, we were only authenticating with an API key, meaning we were using [`AzureKeyCredential`](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/ai.openai-readme?view=azure-dotnet-preview#authenticate-the-client), which ultimately added the API Key in the `api-key` HTTP header. Typically, we used it like this:
```csharp
oaiClient = new OpenAIClient(oaiOptions.Endpoint, new AzureKeyCredential(oaiOptions.Key), oaiClientOptions);
```

By adding a boolean `UseTokenCredentialAuthentication`, if this is true, we would ignore the `Key` value and use Token Credentials, namely a [Microsoft Entra ID Credential Bearer](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/ai.openai-readme?view=azure-dotnet-preview#create-openaiclient-with-a-microsoft-entra-id-credential). Additionally, the `TokenCredentialsOptions` property has been added in case it's necessary to use `ClientSecretCredential`.

With these changes, we can do something like this:

```csharp
OpenAIClient oaiClient;
if (oaiOptions.UseTokenCredentialAuthentication)
{
    var tokenCredentials = new List<TokenCredential>();
    if (oaiOptions.TokenCredentialsOptions != null)
    {
        tokenCredentials.Add(new ClientSecretCredential(oaiOptions.TokenCredentialsOptions.TenantId, oaiOptions.TokenCredentialsOptions.ClientId, oaiOptions.TokenCredentialsOptions.ClientSecret));
    }

    tokenCredentials.Add(new DefaultAzureCredential());

    oaiClient = new OpenAIClient(oaiOptions.Endpoint, new ChainedTokenCredential(tokenCredentials.ToArray()), oaiClientOptions);
}
else
{
    oaiClient = new OpenAIClient(oaiOptions.Endpoint, new AzureKeyCredential(oaiOptions.Key), oaiClientOptions);
}
```