### PR TITLE
Fixed some warnings in Encamina.Enmarcha.Bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Previous classification is not required if changes are simple or all belong to t
 - Fixed warnings CS8603 and CS8025 in:
   - `Encamina.Enmarcha.AI`.
   - `Encamina.Enmarcha.AspNet`
+  - `Encamina.Enmarcha.Bot`
  
 ## [8.1.5]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.6</VersionPrefix>
-    <VersionSuffix>preview-08</VersionSuffix>
+    <VersionSuffix>preview-09</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.AI.QuestionsAnswering.Abstractions/IMetadataProcessor.cs
+++ b/src/Encamina.Enmarcha.AI.QuestionsAnswering.Abstractions/IMetadataProcessor.cs
@@ -19,7 +19,7 @@ public interface IMetadataProcessor
     /// <returns>
     /// A read only collection of answers processed with given metadata options.
     /// </returns>
-    Task<IReadOnlyCollection<IAnswer>> ProcessAnswersAsync(IEnumerable<IAnswer> answers, MetadataOptions metadataOptions, CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<IAnswer>> ProcessAnswersAsync(IEnumerable<IAnswer> answers, MetadataOptions? metadataOptions, CancellationToken cancellationToken);
 
     /// <summary>
     /// Process a message to obtain metadata options from it.

--- a/src/Encamina.Enmarcha.AI.QuestionsAnswering.Abstractions/IQuestionRequestOptions.cs
+++ b/src/Encamina.Enmarcha.AI.QuestionsAnswering.Abstractions/IQuestionRequestOptions.cs
@@ -13,5 +13,5 @@ public interface IQuestionRequestOptions
     /// <summary>
     /// Gets the metadata options.
     /// </summary>
-    MetadataOptions MetadataOptions { get; }
+    MetadataOptions? MetadataOptions { get; }
 }

--- a/src/Encamina.Enmarcha.AI.QuestionsAnswering.Abstractions/QuestionRequestOptions.cs
+++ b/src/Encamina.Enmarcha.AI.QuestionsAnswering.Abstractions/QuestionRequestOptions.cs
@@ -25,5 +25,5 @@ public class QuestionRequestOptions : IQuestionRequestOptions
     public virtual IReadOnlyCollection<string> Sources { get; } = Array.Empty<string>();
 
     /// <inheritdoc/>
-    public virtual MetadataOptions MetadataOptions { get; init; }
+    public virtual MetadataOptions? MetadataOptions { get; init; }
 }

--- a/src/Encamina.Enmarcha.AI.TextsTranslation.Abstractions/ITextTranslationRequest.cs
+++ b/src/Encamina.Enmarcha.AI.TextsTranslation.Abstractions/ITextTranslationRequest.cs
@@ -10,7 +10,7 @@ public interface ITextTranslationRequest
     /// <summary>
     /// Gets the language to translate from.
     /// </summary>
-    CultureInfo FromLanguage { get; init; }
+    CultureInfo? FromLanguage { get; init; }
 
     /// <summary>
     /// Gets the collection of languages to translate.

--- a/src/Encamina.Enmarcha.AI.TextsTranslation.Abstractions/TextTranslationRequest.cs
+++ b/src/Encamina.Enmarcha.AI.TextsTranslation.Abstractions/TextTranslationRequest.cs
@@ -8,7 +8,7 @@ namespace Encamina.Enmarcha.AI.TextsTranslation.Abstractions;
 public class TextTranslationRequest : ITextTranslationRequest
 {
     /// <inheritdoc/>
-    public virtual CultureInfo FromLanguage { get; init; }
+    public virtual CultureInfo? FromLanguage { get; init; }
 
     /// <inheritdoc/>
     public virtual ICollection<CultureInfo> ToLanguages { get; init; } = new List<CultureInfo>();

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/DialogsProviderBase.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/DialogsProviderBase.cs
@@ -51,18 +51,18 @@ public abstract class DialogsProviderBase : IDialogProvider, IIntendedDialogProv
     }
 
     /// <inheritdoc/>
-    public virtual Dialog GetById(string dialogId) => GetDialogByType(dialogsById?[dialogId], d => FilterById(d, dialogId));
+    public virtual Dialog? GetById(string dialogId) => GetDialogByType(dialogsById?[dialogId], d => FilterById(d, dialogId));
 
     /// <inheritdoc/>
-    public virtual Dialog GetByIntent(string dialogIntent) =>
+    public virtual Dialog? GetByIntent(string dialogIntent) =>
         GetDialogByType(dialogsByIntent?[dialogIntent.ToUpperInvariant()], d => FilterByIntent(d, dialogIntent));
 
     /// <inheritdoc/>
-    public virtual Dialog GetByName(string dialogName) =>
+    public virtual Dialog? GetByName(string dialogName) =>
         GetDialogByType(dialogsByName?[dialogName.ToUpperInvariant()], d => FilterByName(d, dialogName));
 
     /// <inheritdoc/>
-    public virtual bool TryGetById(string dialogId, out Dialog dialog)
+    public virtual bool TryGetById(string dialogId, out Dialog? dialog)
     {
         if (dialogsById == null)
         {
@@ -78,7 +78,7 @@ public abstract class DialogsProviderBase : IDialogProvider, IIntendedDialogProv
     }
 
     /// <inheritdoc/>
-    public virtual bool TryGetByIntent(string dialogIntent, out Dialog dialog)
+    public virtual bool TryGetByIntent(string dialogIntent, out Dialog? dialog)
     {
         if (dialogsByIntent == null)
         {
@@ -94,7 +94,7 @@ public abstract class DialogsProviderBase : IDialogProvider, IIntendedDialogProv
     }
 
     /// <inheritdoc/>
-    public virtual bool TryGetByName(string dialogName, out Dialog dialog)
+    public virtual bool TryGetByName(string dialogName, out Dialog? dialog)
     {
         if (dialogsByName == null)
         {
@@ -110,20 +110,20 @@ public abstract class DialogsProviderBase : IDialogProvider, IIntendedDialogProv
     }
 
     /// <inheritdoc/>
-    public virtual Dialog GetByType(Type dialogType, Func<Dialog, bool> filterExpression = null) => GetDialogByType(dialogType, filterExpression);
+    public virtual Dialog? GetByType(Type dialogType, Func<Dialog, bool>? filterExpression = null) => GetDialogByType(dialogType, filterExpression);
 
     /// <inheritdoc/>
-    public virtual T GetByType<T>(Func<Dialog, bool> filterExpression = null) where T : Dialog => GetDialogByType<T>(filterExpression);
+    public virtual T? GetByType<T>(Func<Dialog, bool>? filterExpression = null) where T : Dialog => GetDialogByType<T>(filterExpression);
 
     /// <inheritdoc/>
-    public virtual bool TryGetByType(Type dialogType, out Dialog dialog, Func<Dialog, bool> filterExpression = null)
+    public virtual bool TryGetByType(Type dialogType, out Dialog dialog, Func<Dialog, bool>? filterExpression = null)
     {
         dialog = GetDialogByType(dialogType, filterExpression);
         return dialog != null;
     }
 
     /// <inheritdoc/>
-    public virtual bool TryGetByType<T>(out T dialog, Func<Dialog, bool> filterExpression = null) where T : Dialog
+    public virtual bool TryGetByType<T>(out T dialog, Func<Dialog, bool>? filterExpression = null) where T : Dialog
     {
         dialog = GetDialogByType<T>(filterExpression);
         return dialog != null;
@@ -169,7 +169,7 @@ public abstract class DialogsProviderBase : IDialogProvider, IIntendedDialogProv
         return result;
     }
 
-    private Dialog GetDialogByType(Type dialogType, Func<Dialog, bool> filterPredicate)
+    private Dialog? GetDialogByType(Type dialogType, Func<Dialog, bool> filterPredicate)
     {
         if (dialogType == null)
         {
@@ -180,7 +180,7 @@ public abstract class DialogsProviderBase : IDialogProvider, IIntendedDialogProv
         return (serviceScope.ServiceProvider.GetServices(dialogType) as IEnumerable<Dialog>)?.FirstOrDefault(d => filterPredicate == null || filterPredicate(d));
     }
 
-    private T GetDialogByType<T>(Func<Dialog, bool> filterPredicate) where T : Dialog
+    private T? GetDialogByType<T>(Func<Dialog, bool> filterPredicate) where T : Dialog
     {
         using var serviceScope = serviceProvider.CreateScope();
         return serviceScope.ServiceProvider.GetServices<T>()?.FirstOrDefault(d => filterPredicate == null || filterPredicate(d));

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/DialogsProviderBase.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/DialogsProviderBase.cs
@@ -116,14 +116,14 @@ public abstract class DialogsProviderBase : IDialogProvider, IIntendedDialogProv
     public virtual T? GetByType<T>(Func<Dialog, bool>? filterExpression = null) where T : Dialog => GetDialogByType<T>(filterExpression);
 
     /// <inheritdoc/>
-    public virtual bool TryGetByType(Type dialogType, out Dialog dialog, Func<Dialog, bool>? filterExpression = null)
+    public virtual bool TryGetByType(Type dialogType, out Dialog? dialog, Func<Dialog, bool>? filterExpression = null)
     {
         dialog = GetDialogByType(dialogType, filterExpression);
         return dialog != null;
     }
 
     /// <inheritdoc/>
-    public virtual bool TryGetByType<T>(out T dialog, Func<Dialog, bool>? filterExpression = null) where T : Dialog
+    public virtual bool TryGetByType<T>(out T? dialog, Func<Dialog, bool>? filterExpression = null) where T : Dialog
     {
         dialog = GetDialogByType<T>(filterExpression);
         return dialog != null;
@@ -169,7 +169,7 @@ public abstract class DialogsProviderBase : IDialogProvider, IIntendedDialogProv
         return result;
     }
 
-    private Dialog? GetDialogByType(Type dialogType, Func<Dialog, bool> filterPredicate)
+    private Dialog? GetDialogByType(Type? dialogType, Func<Dialog, bool>? filterPredicate)
     {
         if (dialogType == null)
         {
@@ -180,7 +180,7 @@ public abstract class DialogsProviderBase : IDialogProvider, IIntendedDialogProv
         return (serviceScope.ServiceProvider.GetServices(dialogType) as IEnumerable<Dialog>)?.FirstOrDefault(d => filterPredicate == null || filterPredicate(d));
     }
 
-    private T? GetDialogByType<T>(Func<Dialog, bool> filterPredicate) where T : Dialog
+    private T? GetDialogByType<T>(Func<Dialog, bool>? filterPredicate) where T : Dialog
     {
         using var serviceScope = serviceProvider.CreateScope();
         return serviceScope.ServiceProvider.GetServices<T>()?.FirstOrDefault(d => filterPredicate == null || filterPredicate(d));

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/IDialogProvider.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/IDialogProvider.cs
@@ -14,7 +14,7 @@ public interface IDialogProvider
     /// <returns>
     /// A valid <see cref="Dialog"/>.
     /// </returns>
-    Dialog GetById(string dialogId);
+    Dialog? GetById(string dialogId);
 
     /// <summary>
     /// Tries to get a <see cref="Dialog"/> from its unique identifier.
@@ -28,5 +28,5 @@ public interface IDialogProvider
     /// <returns>
     /// Returns <see langword="true"/> if a valid <see cref="Dialog"/> is found by its unique identifier; otherwise, returns <see langword="false"/>.
     /// </returns>
-    bool TryGetById(string dialogId, out Dialog dialog);
+    bool TryGetById(string dialogId, out Dialog? dialog);
 }

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/IDialogTypeProvider.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/IDialogTypeProvider.cs
@@ -42,7 +42,7 @@ public interface IDialogTypeProvider
     /// <returns>
     /// Returns <see langword="true"/> if a valid <see cref="Dialog"/> is found by its type; otherwise, returns <see langword="false"/>.
     /// </returns>
-    bool TryGetByType(Type dialogType, out Dialog dialog, Func<Dialog, bool>? filterExpression = null);
+    bool TryGetByType(Type dialogType, out Dialog? dialog, Func<Dialog, bool>? filterExpression = null);
 
     /// <summary>
     /// Tries to get a <see cref="Dialog"/> by its type from a generic type parameter.
@@ -57,7 +57,7 @@ public interface IDialogTypeProvider
     /// <returns>
     /// Returns <see langword="true"/> if a valid <see cref="Dialog"/> is found by its type; otherwise, returns <see langword="false"/>.
     /// </returns>
-    bool TryGetByType<T>(out T dialog, Func<Dialog, bool>? filterExpression = null) where T : Dialog;
+    bool TryGetByType<T>(out T? dialog, Func<Dialog, bool>? filterExpression = null) where T : Dialog;
 }
 
 #pragma warning restore S2360 // Optional parameters should not be used

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/IDialogTypeProvider.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/IDialogTypeProvider.cs
@@ -17,7 +17,7 @@ public interface IDialogTypeProvider
     /// <returns>
     /// A valid <see cref="Dialog"/>.
     /// </returns>
-    Dialog GetByType(Type dialogType, Func<Dialog, bool> filterExpression = null);
+    Dialog? GetByType(Type dialogType, Func<Dialog, bool>? filterExpression = null);
 
     /// <summary>
     /// Gets a <see cref="Dialog"/> by its type from a generic type parameter.
@@ -27,7 +27,7 @@ public interface IDialogTypeProvider
     /// <returns>
     /// A valid <see cref="Dialog"/>.
     /// </returns>
-    T GetByType<T>(Func<Dialog, bool> filterExpression = null) where T : Dialog;
+    T? GetByType<T>(Func<Dialog, bool>? filterExpression = null) where T : Dialog;
 
     /// <summary>
     /// Tries to get a <see cref="Dialog"/> from its type.
@@ -42,7 +42,7 @@ public interface IDialogTypeProvider
     /// <returns>
     /// Returns <see langword="true"/> if a valid <see cref="Dialog"/> is found by its type; otherwise, returns <see langword="false"/>.
     /// </returns>
-    bool TryGetByType(Type dialogType, out Dialog dialog, Func<Dialog, bool> filterExpression = null);
+    bool TryGetByType(Type dialogType, out Dialog dialog, Func<Dialog, bool>? filterExpression = null);
 
     /// <summary>
     /// Tries to get a <see cref="Dialog"/> by its type from a generic type parameter.
@@ -57,7 +57,7 @@ public interface IDialogTypeProvider
     /// <returns>
     /// Returns <see langword="true"/> if a valid <see cref="Dialog"/> is found by its type; otherwise, returns <see langword="false"/>.
     /// </returns>
-    bool TryGetByType<T>(out T dialog, Func<Dialog, bool> filterExpression = null) where T : Dialog;
+    bool TryGetByType<T>(out T dialog, Func<Dialog, bool>? filterExpression = null) where T : Dialog;
 }
 
 #pragma warning restore S2360 // Optional parameters should not be used

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/IIntendedDialogProvider.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/IIntendedDialogProvider.cs
@@ -14,7 +14,7 @@ public interface IIntendedDialogProvider
     /// <returns>
     /// A valid <see cref="Dialog"/>.
     /// </returns>
-    Dialog GetByIntent(string dialogIntent);
+    Dialog? GetByIntent(string dialogIntent);
 
     /// <summary>
     /// Tries to get a <see cref="Dialog"/> from its intent.
@@ -28,5 +28,5 @@ public interface IIntendedDialogProvider
     /// <returns>
     /// Returns <see langword="true"/> if a valid <see cref="Dialog"/> is found by its intent; otherwise, returns <see langword="false"/>.
     /// </returns>
-    bool TryGetByIntent(string dialogIntent, out Dialog dialog);
+    bool TryGetByIntent(string dialogIntent, out Dialog? dialog);
 }

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/INamedDialogProvider.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/INamedDialogProvider.cs
@@ -14,7 +14,7 @@ public interface INamedDialogProvider
     /// <returns>
     /// A valid <see cref="Dialog"/>.
     /// </returns>
-    Dialog GetByName(string dialogName);
+    Dialog? GetByName(string dialogName);
 
     /// <summary>
     /// Tries to get a <see cref="Dialog"/> from its name.
@@ -28,5 +28,5 @@ public interface INamedDialogProvider
     /// <returns>
     /// Returns <see langword="true"/> if a valid <see cref="Dialog"/> is found by its name; otherwise, returns <see langword="false"/>.
     /// </returns>
-    bool TryGetByName(string dialogName, out Dialog dialog);
+    bool TryGetByName(string dialogName, out Dialog? dialog);
 }

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/NamedComponentDialogBase.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/NamedComponentDialogBase.cs
@@ -13,7 +13,7 @@ public class NamedComponentDialogBase : ComponentDialog, INameableDialog
     /// <summary>
     /// Initializes a new instance of the <see cref="NamedComponentDialogBase"/> class.
     /// </summary>
-    protected NamedComponentDialogBase() : this(null)
+    protected NamedComponentDialogBase() : this(null!)
     {
     }
 

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/NamedComponentDialogBase.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/NamedComponentDialogBase.cs
@@ -13,7 +13,7 @@ public class NamedComponentDialogBase : ComponentDialog, INameableDialog
     /// <summary>
     /// Initializes a new instance of the <see cref="NamedComponentDialogBase"/> class.
     /// </summary>
-    protected NamedComponentDialogBase() : this(null!)
+    protected NamedComponentDialogBase() : this(null)
     {
     }
 
@@ -21,7 +21,7 @@ public class NamedComponentDialogBase : ComponentDialog, INameableDialog
     /// Initializes a new instance of the <see cref="NamedComponentDialogBase"/> class.
     /// </summary>
     /// <param name="dialogId">The unique identifier for this dialog.</param>
-    protected NamedComponentDialogBase(string dialogId) : base(dialogId)
+    protected NamedComponentDialogBase(string? dialogId) : base(dialogId)
     {
     }
 

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/NamedDialogBase.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/NamedDialogBase.cs
@@ -13,7 +13,7 @@ public abstract class NamedDialogBase : Dialog, INameableDialog
     /// <summary>
     /// Initializes a new instance of the <see cref="NamedDialogBase"/> class.
     /// </summary>
-    protected NamedDialogBase() : this(null)
+    protected NamedDialogBase() : this(null!)
     {
     }
 

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/NamedDialogBase.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Dialogs/NamedDialogBase.cs
@@ -13,7 +13,7 @@ public abstract class NamedDialogBase : Dialog, INameableDialog
     /// <summary>
     /// Initializes a new instance of the <see cref="NamedDialogBase"/> class.
     /// </summary>
-    protected NamedDialogBase() : this(null!)
+    protected NamedDialogBase() : this(null)
     {
     }
 
@@ -21,7 +21,7 @@ public abstract class NamedDialogBase : Dialog, INameableDialog
     /// Initializes a new instance of the <see cref="NamedDialogBase"/> class.
     /// </summary>
     /// <param name="dialogId">The unique identifier for this dialog.</param>
-    protected NamedDialogBase(string dialogId) : base(dialogId)
+    protected NamedDialogBase(string? dialogId) : base(dialogId)
     {
     }
 

--- a/src/Encamina.Enmarcha.Bot.Abstractions/QuestionAnswering/SendResponseResult.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/QuestionAnswering/SendResponseResult.cs
@@ -36,5 +36,5 @@ public class SendResponseResult
     /// <summary>
     /// Gets the resource response.
     /// </summary>
-    public ResourceResponse ResourceResponse { get; init; }
+    public ResourceResponse? ResourceResponse { get; init; }
 }

--- a/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/Extensions/IServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Encamina.Enmarcha.AI.Abstractions;
+﻿#pragma warning disable S2360 // Optional parameters should not be used
+
+using Encamina.Enmarcha.AI.Abstractions;
 using Encamina.Enmarcha.AI.QuestionsAnswering.Abstractions;
 
 using Encamina.Enmarcha.Bot.Skills.QuestionAnswering;
@@ -10,8 +12,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
 using ExceptionMessages = Encamina.Enmarcha.Bot.Skills.QuestionAnswering.Resources.ExceptionMessages;
-
-#pragma warning disable S2360 // Optional parameters should not be used
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/QuestionAnsweringDialog.cs
+++ b/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/QuestionAnsweringDialog.cs
@@ -59,9 +59,9 @@ internal sealed class QuestionAnsweringDialog : NamedDialogBase, IIntendable
     public override string Name => string.IsNullOrWhiteSpace(configurationOptions.DialogName) ? base.Name : configurationOptions.DialogName;
 
     /// <inheritdoc/>
-    public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
+    public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object? options = null, CancellationToken cancellationToken = default)
     {
-        ResourceResponse response = null;
+        ResourceResponse? response = null;
 
         if (dc.Context.Activity.Type == ActivityTypes.Message && !string.IsNullOrWhiteSpace(dc.Context.Activity.Text))
         {
@@ -141,7 +141,7 @@ internal sealed class QuestionAnsweringDialog : NamedDialogBase, IIntendable
         return answers;
     }
 
-    private async Task<ResourceResponse> SendAnswerAsync(IEnumerable<IAnswer> answers, ITurnContext turnContext, CancellationToken cancellationToken)
+    private async Task<ResourceResponse?> SendAnswerAsync(IEnumerable<IAnswer> answers, ITurnContext turnContext, CancellationToken cancellationToken)
     {
         var verbose = configurationOptions.Verbose || VerboseFromTurnContextValue(turnContext);
 

--- a/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/QuestionAnsweringDialog.cs
+++ b/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/QuestionAnsweringDialog.cs
@@ -59,7 +59,7 @@ internal sealed class QuestionAnsweringDialog : NamedDialogBase, IIntendable
     public override string Name => string.IsNullOrWhiteSpace(configurationOptions.DialogName) ? base.Name : configurationOptions.DialogName;
 
     /// <inheritdoc/>
-    public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object? options = null, CancellationToken cancellationToken = default)
+    public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
     {
         ResourceResponse? response = null;
 

--- a/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/QuestionAnsweringDialog.cs
+++ b/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/QuestionAnsweringDialog.cs
@@ -85,7 +85,7 @@ internal sealed class QuestionAnsweringDialog : NamedDialogBase, IIntendable
         return await dc.EndDialogAsync(response, cancellationToken);
     }
 
-    private static IActivity BuildMessageActivity(string message, bool withVerbose, IEnumerable<IAnswer> answers)
+    private static IActivity BuildMessageActivity(string message, bool withVerbose, IEnumerable<IAnswer>? answers)
     {
         var activity = MessageFactory.Text(message, message);
 
@@ -102,7 +102,7 @@ internal sealed class QuestionAnsweringDialog : NamedDialogBase, IIntendable
         return turnContext.Activity.Value is JObject activityValue && (activityValue[Constants.ActivityValueVerbose]?.Value<bool>() ?? false);
     }
 
-    private async Task<QuestionRequest> BuildQuestionRequestAsync(string question, string userId, MetadataOptions metadataOptions, IEnumerable<string> sources, CancellationToken cancellationToken)
+    private async Task<QuestionRequest> BuildQuestionRequestAsync(string question, string userId, MetadataOptions? metadataOptions, IEnumerable<string> sources, CancellationToken cancellationToken)
     {
         var questionRequestOptions = new QuestionRequestOptions(sources)
         {
@@ -119,7 +119,7 @@ internal sealed class QuestionAnsweringDialog : NamedDialogBase, IIntendable
             };
     }
 
-    private async Task<IEnumerable<IAnswer>> ProcessQuestionResultAsync(QuestionResult result, MetadataOptions metadataOptions, IEnumerable<string> sources, CancellationToken cancellationToken)
+    private async Task<IEnumerable<IAnswer>> ProcessQuestionResultAsync(QuestionResult result, MetadataOptions? metadataOptions, IEnumerable<string> sources, CancellationToken cancellationToken)
     {
         IEnumerable<IAnswer> answers = result.Answers;
 

--- a/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/QuestionAnsweringDialogServices.cs
+++ b/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/QuestionAnsweringDialogServices.cs
@@ -9,10 +9,10 @@ using Microsoft.Bot.Builder;
 namespace Encamina.Enmarcha.Bot.Skills.QuestionAnswering;
 
 internal record class QuestionAnsweringDialogServices(ICognitiveServiceFactory<IQuestionAnsweringService> QuestionAnsweringCognitiveServiceFactory,
-    IBotTelemetryClient BotTelemetryClient = null,
-    ISourcesProcessor SourcesProcessor = null,
-    IMetadataProcessor MetadataProcessor = null,
-    IQuestionRequestProcessor QuestionRequestProcessor = null,
-    IQuestionResultProcessor QuestionResultProcessor = null,
-    ISendAnswersProcessor SendAnswersProcessor = null,
-    IIntentResponsesProvider IntentResponsesProvider = null);
+    IBotTelemetryClient? BotTelemetryClient = null,
+    ISourcesProcessor? SourcesProcessor = null,
+    IMetadataProcessor? MetadataProcessor = null,
+    IQuestionRequestProcessor? QuestionRequestProcessor = null,
+    IQuestionResultProcessor? QuestionResultProcessor = null,
+    ISendAnswersProcessor? SendAnswersProcessor = null,
+    IIntentResponsesProvider? IntentResponsesProvider = null);

--- a/src/Encamina.Enmarcha.Bot/Adapters/BotCloudAdapterWithErrorHandlerBase.cs
+++ b/src/Encamina.Enmarcha.Bot/Adapters/BotCloudAdapterWithErrorHandlerBase.cs
@@ -47,7 +47,7 @@ public class BotCloudAdapterWithErrorHandlerBase : CloudAdapter
     /// <summary>
     /// Gets this adapter's options.
     /// </summary>
-    protected virtual IBotAdapterOptions<BotCloudAdapterWithErrorHandlerBase> Options { get; init; }
+    protected virtual IBotAdapterOptions<BotCloudAdapterWithErrorHandlerBase>? Options { get; init; }
 
     /// <summary>
     /// An error handler that can catch exceptions in the middleware or application.

--- a/src/Encamina.Enmarcha.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Encamina.Enmarcha.Bot.QuestionAnswering;
 using Encamina.Enmarcha.Bot.Responses;
 
 using Encamina.Enmarcha.Core.Extensions;
+#pragma warning disable S2360 // Optional parameters should not be used
 
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -28,8 +29,6 @@ using Microsoft.Extensions.Configuration;
 
 using ExceptionMessages = Encamina.Enmarcha.Bot.Resources.ExceptionMessages;
 using IMiddleware = Microsoft.Bot.Builder.IMiddleware;
-
-#pragma warning disable S2360 // Optional parameters should not be used
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -250,7 +249,7 @@ public static class IServiceCollectionExtensions
         where TBotMiddleware : class, IMiddleware
     {
         return services.TryAddType(serviceLifetime, implementationFactory)
-                       .AddType<IMiddleware, TBotMiddleware>(serviceLifetime, serviceProvider => serviceProvider.GetService<TBotMiddleware>());
+                       .AddType<IMiddleware, TBotMiddleware>(serviceLifetime, serviceProvider => serviceProvider.GetService<TBotMiddleware>()!);
     }
 
     /// <summary>

--- a/src/Encamina.Enmarcha.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Globalization;
+﻿#pragma warning disable S2360 // Optional parameters should not be used
+
+using System.Globalization;
 
 using Encamina.Enmarcha.AI;
 
@@ -11,7 +13,6 @@ using Encamina.Enmarcha.Bot.QuestionAnswering;
 using Encamina.Enmarcha.Bot.Responses;
 
 using Encamina.Enmarcha.Core.Extensions;
-#pragma warning disable S2360 // Optional parameters should not be used
 
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -71,7 +72,7 @@ public static class IServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds a bot transcript logger middleware as singleton using a memory trasncript store.
+    /// Adds a bot transcript logger middleware as singleton using a memory transcript store.
     /// </summary>
     /// <remarks>This extension method uses the <see cref="MemoryTranscriptStore"/> transcript store.</remarks>
     /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
@@ -84,7 +85,7 @@ public static class IServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds a bot transcript logger middleware as singleton using a Blob container as trasncript logger (and store).
+    /// Adds a bot transcript logger middleware as singleton using a Blob container as transcript logger (and store).
     /// </summary>
     /// <remarks>This extension method uses the <see cref="BlobsTranscriptStore"/> transcript store.</remarks>
     /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
@@ -114,13 +115,13 @@ public static class IServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds a bot transcript logger middleware as singleton using a file storage as trasncript store.
+    /// Adds a bot transcript logger middleware as singleton using a file storage as transcript store.
     /// </summary>
     /// <remarks>This extension method uses the <see cref="MemoryTranscriptStore"/> transcript store.</remarks>
     /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="folder">A folder path to place the transcript files.</param>
     /// <param name="overwriteTranscriptFiles">
-    /// A flag to indicate if transcript files should be overriten or not. This is usually helpful for unit test scenariuos. Default value is <see langword="false"/>.
+    /// A flag to indicate if transcript files should be overwritten or not. This is usually helpful for unit test scenarios. Default value is <see langword="false"/>.
     /// </param>
     /// <param name="serviceLifetime">The lifetime for the <see cref="MemoryTranscriptStore"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
@@ -226,7 +227,7 @@ public static class IServiceCollectionExtensions
     /// <summary>
     /// Adds a bot middleware.
     /// </summary>
-    /// <typeparam name="TBotMiddleware">The type of a specific bot middlerware. It must implement interface <see cref="IMiddleware"/>.</typeparam>
+    /// <typeparam name="TBotMiddleware">The type of a specific bot middleware. It must implement interface <see cref="IMiddleware"/>.</typeparam>
     /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="serviceLifetime">The lifetime for the <typeparamref name="TBotMiddleware"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
@@ -238,9 +239,9 @@ public static class IServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds a bot middlerware from an implementation factory.
+    /// Adds a bot middleware from an implementation factory.
     /// </summary>
-    /// <typeparam name="TBotMiddleware">The type of a specific bot middlerware. It must implement interface <see cref="IMiddleware"/>.</typeparam>
+    /// <typeparam name="TBotMiddleware">The type of a specific bot middleware. It must implement interface <see cref="IMiddleware"/>.</typeparam>
     /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="implementationFactory">The factory that creates the service.</param>
     /// <param name="serviceLifetime">The lifetime for the <typeparamref name="TBotMiddleware"/>.</param>

--- a/src/Encamina.Enmarcha.Bot/Greetings/LocalizedHeroCardGreetingsOptionsFromTableStorage.cs
+++ b/src/Encamina.Enmarcha.Bot/Greetings/LocalizedHeroCardGreetingsOptionsFromTableStorage.cs
@@ -36,7 +36,7 @@ internal class LocalizedHeroCardGreetingsOptionsFromTableStorage : ILocalizedHer
     /// The absolute expiration time, relative to now in seconds for a cache to store values retrieved from the Table Storage, to improve performance. Default <c>86400</c> (i.e., 24 hours - 1 day).
     /// </param>
     /// <param name="memoryCache">An optional valid instance of a memory cache to improve performance by storing parameters and values retrieved from the Table Storage.</param>
-    public LocalizedHeroCardGreetingsOptionsFromTableStorage(string tableConnectionString, string tableName, string defaultLocale, double cacheAbsoluteExpirationSeconds = 86400, IMemoryCache memoryCache = null)
+    public LocalizedHeroCardGreetingsOptionsFromTableStorage(string tableConnectionString, string tableName, string defaultLocale, double cacheAbsoluteExpirationSeconds = 86400, IMemoryCache? memoryCache = null)
         : this(tableConnectionString, tableName, CultureInfo.GetCultureInfo(defaultLocale), cacheAbsoluteExpirationSeconds, memoryCache)
     {
     }
@@ -51,7 +51,7 @@ internal class LocalizedHeroCardGreetingsOptionsFromTableStorage : ILocalizedHer
     /// The absolute expiration time, relative to now in seconds for a cache to store values retrieved from the Table Storage, to improve performance. Default <c>86400</c> (i.e., 24 hours - 1 day).
     /// </param>
     /// <param name="memoryCache">An optional valid instance of a memory cache to improve performance by storing parameters and values retrieved from the Table Storage.</param>
-    public LocalizedHeroCardGreetingsOptionsFromTableStorage(string tableConnectionString, string tableName, CultureInfo defaultLocale, double cacheAbsoluteExpirationSeconds = 86400, IMemoryCache memoryCache = null)
+    public LocalizedHeroCardGreetingsOptionsFromTableStorage(string tableConnectionString, string tableName, CultureInfo defaultLocale, double cacheAbsoluteExpirationSeconds = 86400, IMemoryCache? memoryCache = null)
     {
         Guard.IsNotNullOrWhiteSpace(tableConnectionString);
         Guard.IsNotNullOrWhiteSpace(tableName);

--- a/src/Encamina.Enmarcha.Bot/Logging/ApplicationInsightsConversationScopedLoggerEventSource.cs
+++ b/src/Encamina.Enmarcha.Bot/Logging/ApplicationInsightsConversationScopedLoggerEventSource.cs
@@ -27,7 +27,7 @@ internal sealed class ApplicationInsightsConversationScopedLoggerEventSource : E
     /// <param name="error">The error message to log.</param>
     /// <param name="applicationName">The name of the application.</param>
     [Event(1, Message = "Sending log to ApplicationInsigthsConversationScopedLoggerProvider has failed. Error: {0}", Level = EventLevel.Error)]
-    public void FailedToLog(string error, string applicationName = null)
+    public void FailedToLog(string error, string? applicationName = null)
     {
         WriteEvent(1, error, applicationName ?? this.applicationName);
     }

--- a/src/Encamina.Enmarcha.Bot/Logging/ApplicationInsigthsConversationScopedLogger.cs
+++ b/src/Encamina.Enmarcha.Bot/Logging/ApplicationInsigthsConversationScopedLogger.cs
@@ -68,7 +68,7 @@ internal sealed class ApplicationInsigthsConversationScopedLogger : ILogger
     }
 
     /// <inheritdoc />
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception?, string> formatter)
     {
         if (formatter == null)
         {

--- a/src/Encamina.Enmarcha.Bot/Middlewares/DetectedLanguageTranslatorMiddleware.cs
+++ b/src/Encamina.Enmarcha.Bot/Middlewares/DetectedLanguageTranslatorMiddleware.cs
@@ -37,7 +37,7 @@ public class DetectedLanguageTranslatorMiddleware : IMiddleware
     /// A cognitive service provider to locate a language detection and a text translation services from the given names.
     /// </param>
     public DetectedLanguageTranslatorMiddleware(CultureInfo translateToLanguage, IEnumerable<CultureInfo> languageExceptions, string languageDetectionServiceName, string textTranslationServiceName, ICognitiveServiceProvider cognitiveServiceProvider)
-        : this(translateToLanguage, languageExceptions, cognitiveServiceProvider?.GetLanguageDetectionService(languageDetectionServiceName), cognitiveServiceProvider?.GetTextTranslationService(textTranslationServiceName))
+        : this(translateToLanguage, languageExceptions, cognitiveServiceProvider.GetLanguageDetectionService(languageDetectionServiceName), cognitiveServiceProvider.GetTextTranslationService(textTranslationServiceName))
     {
     }
 
@@ -66,7 +66,7 @@ public class DetectedLanguageTranslatorMiddleware : IMiddleware
     /// any of the exception languages, then it will be translated into the translation language before passing it down the pipeline.
     /// </para>
     /// <para>
-    /// When returning, it also process outgoint activities to translate back.
+    /// When returning, it also process outgoing activities to translate back.
     /// </para>
     /// </summary>
     /// <param name="turnContext">The context object for this turn.</param>

--- a/src/Encamina.Enmarcha.Bot/Middlewares/StartActivityTranslatorMiddleware.cs
+++ b/src/Encamina.Enmarcha.Bot/Middlewares/StartActivityTranslatorMiddleware.cs
@@ -13,7 +13,7 @@ using Microsoft.Bot.Schema;
 namespace Encamina.Enmarcha.Bot.Middlewares;
 
 /// <summary>
-/// Middleware to automatically translate messages sent to consumers duting start activities into the language
+/// Middleware to automatically translate messages sent to consumers during start activities into the language
 /// received as <see cref="Activity.Locale"/>.
 /// </summary>
 /// <remarks>
@@ -31,7 +31,7 @@ public class StartActivityTranslatorMiddleware : IMiddleware
     /// A cognitive service provider to locate a language detection and a text translation services from the given names.
     /// </param>
     public StartActivityTranslatorMiddleware(string textTranslationServiceName, ICognitiveServiceProvider cognitiveServiceProvider)
-        : this(cognitiveServiceProvider?.GetTextTranslationService(textTranslationServiceName))
+        : this(cognitiveServiceProvider.GetTextTranslationService(textTranslationServiceName))
     {
     }
 

--- a/src/Encamina.Enmarcha.Bot/Middlewares/TranslatorUtils.cs
+++ b/src/Encamina.Enmarcha.Bot/Middlewares/TranslatorUtils.cs
@@ -36,13 +36,13 @@ internal static class TranslatorUtils
     /// <param name="toLanguage">The language to translate to.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>A task that represents the asynchronous error handling operation.</returns>
-    internal static async Task TranslateMessagesAsync(ITextTranslationService translationService, IList<Activity> activities, CultureInfo fromLanguage, CultureInfo toLanguage, CancellationToken cancellationToken)
+    internal static async Task TranslateMessagesAsync(ITextTranslationService translationService, IList<Activity> activities, CultureInfo? fromLanguage, CultureInfo toLanguage, CancellationToken cancellationToken)
     {
         var messageActivities = activities?.Where(a => a.Type == ActivityTypes.Message);
 
         if (messageActivities?.Any() ?? false)
         {
-            // Use an index as translation identifier to keep track of translatable items, which could be more than just the message, since it might also include attachemnts and other elements.
+            // Use an index as translation identifier to keep track of translatable items, which could be more than just the message, since it might also include attachments and other elements.
             var index = 0;
             var translatableItems = new Dictionary<string, string>();
 

--- a/src/Encamina.Enmarcha.Bot/Middlewares/TranslatorUtils.cs
+++ b/src/Encamina.Enmarcha.Bot/Middlewares/TranslatorUtils.cs
@@ -22,7 +22,7 @@ internal static class TranslatorUtils
     /// <returns>
     /// The trasnslated text in the given <paramref name="language"/> or the given default value from <paramref name="default"/>.
     /// </returns>
-    internal static string GetTranslation(IDictionary<string, string> translations, CultureInfo language, string @default = @"")
+    internal static string GetTranslation(IDictionary<string, string>? translations, CultureInfo language, string @default = @"")
     {
         return translations != null && (translations.TryGetValue(language.Name, out var value) || translations.TryGetValue(language.Parent.Name, out value)) ? value : @default;
     }

--- a/src/Encamina.Enmarcha.Bot/Responses/TableStorageResponseProvider.cs
+++ b/src/Encamina.Enmarcha.Bot/Responses/TableStorageResponseProvider.cs
@@ -43,7 +43,7 @@ internal class TableStorageResponseProvider : IIntentResponsesProvider
         string defaultLocale,
         string intentCounterSeparator = @"-",
         double cacheAbsoluteExpirationSeconds = 86400,
-        IMemoryCache memoryCache = null)
+        IMemoryCache? memoryCache = null)
     {
         Guard.IsNotNullOrWhiteSpace(tableConnectionString);
         Guard.IsNotNullOrWhiteSpace(tableName);

--- a/src/Encamina.Enmarcha.Bot/Responses/TableStorageResponseProvider.cs
+++ b/src/Encamina.Enmarcha.Bot/Responses/TableStorageResponseProvider.cs
@@ -32,7 +32,7 @@ internal class TableStorageResponseProvider : IIntentResponsesProvider
     /// <param name="defaultLocale">Default locale.</param>
     /// <param name="intentCounterSeparator">
     /// An optional value that represents the intent counter separation (i.e., a value that helps separating the intent
-    /// label from a numeric value that represens its order or instance number). Defaults to '<c>-</c>'.
+    /// label from a numeric value that represents its order or instance number). Defaults to '<c>-</c>'.
     /// </param>
     /// <param name="cacheAbsoluteExpirationSeconds">
     /// An optional value for absolute expiration time in seconds for the cache. Defaults to '<c>86400</c>' seconds.
@@ -66,11 +66,13 @@ internal class TableStorageResponseProvider : IIntentResponsesProvider
     /// <inheritdoc/>
     public virtual async Task<IReadOnlyCollection<Response>> GetResponsesAsync(string intent, CultureInfo culture, CancellationToken cancellationToken)
     {
-        var intentsByLocale = await memoryCache?.GetOrCreate(CacheKey, async cacheEntry =>
+        var intentsByLocale = memoryCache != null
+        ? await memoryCache.GetOrCreateAsync(CacheKey, async cacheEntry =>
         {
-            cacheEntry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(cacheAbsoluteExpirationSeconds);
-            return await InitAsync(cancellationToken);
-        }) ?? await InitAsync(cancellationToken);
+             cacheEntry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(cacheAbsoluteExpirationSeconds);
+             return await InitAsync(cancellationToken);
+        })
+        : await InitAsync(cancellationToken);
 
         return (intentsByLocale.TryGetValue(culture.Name.ToUpperInvariant(), out var responsesByIntent) ||
                 intentsByLocale.TryGetValue(culture.Parent.Name.ToUpperInvariant(), out responsesByIntent) ||


### PR DESCRIPTION
- Realized minor refactoring in IMetadataProcessor, IQuestionRequestOptions, QuestionRequestOptions, allowing MetadataOptions to be null to resolve various warnings (CS8602, CS8604).
- Updated ITextTranslationRequest and TextTranslationRequest to specify that CultureInfo can be null, addressing warning CS8603.
- Refactored DialogsProviderBase, IDialogProvider, IDialogTypeProvider, ITendedDialogProvider, INamedDialogProvider, NamedComponentDialogBase, and NamedDialogBase to resolve warnings (CS8602, CS8603, and CS8625).
- Modified SendResponseResult to indicate that ResourceResponse can be null, resolving warning CS8063.
- Performed code cleanup in IServiceCollectionExtensions of Encamina.Enmarcha.Bot.Skills to adjust the positioning of a pragma.
- Updated QuestionAnsweringDialog and QuestionAnsweringDialogServices to address warnings CS8603 and CS8625.
- Modified BotCloudAdapterWithErrorHandlerBase to specify that options can be null, resolving warning CS8603.
- Refactored IServiceCollectionExtensions of Encamina.Enmarcha.Bot to resolve warning CS8603 and ensure the service received cannot be null, in addition to performing minor code cleanup and pragma repositioning.
- Updated LocalizedHeroCardGreetingsOptionsFromTableStorage to resolve warnings CS8603.
- Revised ApplicationInsightsConversationScopedLoggerEventSource to resolve warning CS8603 by making applicationName nullable, and adjusted ApplicationInsightsConversationScopedLogger to resolve warning CS8602 by making Exception nullable.
- Removed the possibility of cognitiveServiceProvider being null in DetectedLanguageTranslatorMiddleware and StartActivityTranslatorMiddleware, and performed minor code cleanup in the descriptions.
- Conducted minor code cleanup in TranslatorUtils and adjusted translations to be nullable to resolve warning CS8603.
- Updated TableStorageResponseProvider to specify that IMemoryCache can be null, resolving warning CS8603.