### PR TITLE
Release `8.1.6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,13 +50,13 @@ Previous classification is not required if changes are simple or all belong to t
   - Updated `Microsoft.Extensions.Logging.Abstractions` from `8.0.0` to `8.0.1`.
   - Updated `Microsoft.Extensions.Azure` from `1.7.2` to `1.7.3`.
   - Updated `Microsoft.Extensions.DependencyInjection.Abstractions` from `8.0.0` to `8.0.1`.
-  - Updated `Microsoft.SemanticKernel.Abstractions` from `1.6.2` to `1.7.1`.
-  - Updated `Microsoft.SemanticKernel.Connectors.AzureAISearch` from `1.6.2-alpha` to `1.7.1-alpha`. This does fix the [Issue 72](https://github.com/Encamina/enmarcha/issues/72).
-  - Updated `Microsoft.SemanticKernel.Connectors.OpenAI` from `1.6.2` to `1.7.1`.
-  - Updated `Microsoft.SemanticKernel.Connectors.Qdrant` from `1.6.2-alpha` to `1.7.1-alpha`.
-  - Updated `Microsoft.SemanticKernel.Core` from `1.6.2` to `1.7.1`.
-  - Updated `Microsoft.SemanticKernel.Plugins.Document` from `1.6.2-alpha` to `1.7.1-alpha`.
-  - Updated `Microsoft.SemanticKernel.Plugins.Memory` from `1.6.2-alpha` to `1.7.1-alpha`.
+  - Updated `Microsoft.SemanticKernel.Abstractions` from `1.6.2` to `1.10.0`.
+  - Updated `Microsoft.SemanticKernel.Connectors.AzureAISearch` from `1.6.2-alpha` to `1.10.0-alpha`. This does fix the [Issue 72](https://github.com/Encamina/enmarcha/issues/72).
+  - Updated `Microsoft.SemanticKernel.Connectors.OpenAI` from `1.6.2` to `1.10.0`.
+  - Updated `Microsoft.SemanticKernel.Connectors.Qdrant` from `1.6.2-alpha` to `1.10.0-alpha`.
+  - Updated `Microsoft.SemanticKernel.Core` from `1.6.2` to `1.10.0`.
+  - Updated `Microsoft.SemanticKernel.Plugins.Document` from `1.6.2-alpha` to `1.10.0-alpha`.
+  - Updated `Microsoft.SemanticKernel.Plugins.Memory` from `1.6.2-alpha` to `1.10.0-alpha`.
   - Updated `SharpToken` from `1.2.17` to `2.0.2`.
   - Updated `System.Text.Json` from `8.0.2` to `8.0.3`.
   - Updated `coverlet.collector` from `6.0.1` to `6.0.2`.
@@ -80,6 +80,7 @@ Previous classification is not required if changes are simple or all belong to t
 - Fixed warnings CS8603 and CS8025 in:
   - `Encamina.Enmarcha.AI`.
   - `Encamina.Enmarcha.AspNet`
+- Corrected a typo in the Spanish error message in `ResponseMessages.es.resx` from "ha encontrar" to "ha encontrado".
  
 ## [8.1.5]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.6</VersionPrefix>
-    <VersionSuffix>preview-08</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering.csproj
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering/Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.7.1-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.10.0-alpha" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Encamina.Enmarcha.Bot/Resources/ResponseMessages.es.resx
+++ b/src/Encamina.Enmarcha.Bot/Resources/ResponseMessages.es.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="GeneralBotErrorResponse" xml:space="preserve">
-    <value>El bot ha encontrar un error. Por favor proporcione el siguiente identificador para rastrear el error: {0}</value>
+    <value>El bot ha encontrado un error. Por favor proporcione el siguiente identificador para rastrear el error: {0}</value>
   </data>
 </root>

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
@@ -17,8 +17,8 @@
     </PropertyGroup>
 
     <ItemGroup>        
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.7.1" PrivateAssets="none" />
-        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.7.1" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.10.0" PrivateAssets="none" />
+        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.10.0" />
         <PackageReference Include="SharpToken" Version="2.0.2" />
     </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
@@ -20,7 +20,7 @@
     
   <ItemGroup>
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.7.1-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.10.0-alpha" />
     <PackageReference Include="PdfPig" Version="0.1.8" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Memory/Encamina.Enmarcha.SemanticKernel.Connectors.Memory.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Memory/Encamina.Enmarcha.SemanticKernel.Connectors.Memory.csproj
@@ -21,8 +21,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.7.1-alpha" />
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.7.1-alpha" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.10.0-alpha" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.10.0-alpha" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.7.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.10.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.7.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.10.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.7.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated various `Microsoft.SemanticKernel` package versions across multiple `.csproj` files from `1.7.1` and `1.7.1-alpha` to `1.10.0` and `1.10.0-alpha` respectively. This includes updates to `Microsoft.SemanticKernel.Plugins.Memory`, `Microsoft.SemanticKernel.Connectors.OpenAI`, `Microsoft.SemanticKernel.Core`, `Microsoft.SemanticKernel.Plugins.Document`, `Microsoft.SemanticKernel.Connectors.AzureAISearch`, `Microsoft.SemanticKernel.Connectors.Qdrant`, and `Microsoft.SemanticKernel.Abstractions` in various projects. 

Also, corrected a typo in the Spanish error message in `ResponseMessages.es.resx` from "ha encontrar" to "ha encontrado".