### PR TITLE
Fixed warnings in Encamina.Enmarcha.Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Previous classification is not required if changes are simple or all belong to t
   - `Encamina.Enmarcha.AI`.
   - `Encamina.Enmarcha.AspNet`
   - `Encamina.Enmarcha.Bot`
+  - `Encamina.Enmarcha.Core`
  
 ## [8.1.5]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.6</VersionPrefix>
-    <VersionSuffix>preview-09</VersionSuffix>
+    <VersionSuffix>preview-10</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/GuidNotEmptyAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/GuidNotEmptyAttribute.cs
@@ -19,13 +19,13 @@ public sealed class GuidNotEmptyAttribute : ValidationAttribute
     /// <remarks>
     /// A null value is accepted as valid since the idea of «Not Empty» doesn't necessarily means «Required».
     /// </remarks>
-    public override bool IsValid(object value) => value == null || (value is Guid s && s != Guid.Empty);
+    public override bool IsValid(object? value) => value == null || (value is Guid s && s != Guid.Empty);
 
     /// <inheritdoc/>
     /// <remarks>
     /// A null value is accepted as valid since the idea of «Not Empty» doesn't necessarily means «Required».
     /// </remarks>
-    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         return IsValid(value)
             ? ValidationResult.Success

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/GuidNotEmptyAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/GuidNotEmptyAttribute.cs
@@ -25,7 +25,7 @@ public sealed class GuidNotEmptyAttribute : ValidationAttribute
     /// <remarks>
     /// A null value is accepted as valid since the idea of «Not Empty» doesn't necessarily means «Required».
     /// </remarks>
-    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
     {
         return IsValid(value)
             ? ValidationResult.Success

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/GuidNotEmptyAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/GuidNotEmptyAttribute.cs
@@ -19,13 +19,13 @@ public sealed class GuidNotEmptyAttribute : ValidationAttribute
     /// <remarks>
     /// A null value is accepted as valid since the idea of «Not Empty» doesn't necessarily means «Required».
     /// </remarks>
-    public override bool IsValid(object? value) => value == null || (value is Guid s && s != Guid.Empty);
+    public override bool IsValid(object value) => value == null || (value is Guid s && s != Guid.Empty);
 
     /// <inheritdoc/>
     /// <remarks>
     /// A null value is accepted as valid since the idea of «Not Empty» doesn't necessarily means «Required».
     /// </remarks>
-    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
     {
         return IsValid(value)
             ? ValidationResult.Success

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/NotEmptyOrWhitespaceAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/NotEmptyOrWhitespaceAttribute.cs
@@ -17,10 +17,10 @@ namespace Encamina.Enmarcha.Core.DataAnnotations;
 public sealed class NotEmptyOrWhitespaceAttribute : ValidationAttribute
 {
     /// <inheritdoc/>
-    public override bool IsValid(object? value) => value == null || (value is string s && !string.IsNullOrWhiteSpace(s));
+    public override bool IsValid(object value) => value == null || (value is string s && !string.IsNullOrWhiteSpace(s));
 
     /// <inheritdoc/>
-    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
     {
         return IsValid(value)
             ? ValidationResult.Success

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/NotEmptyOrWhitespaceAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/NotEmptyOrWhitespaceAttribute.cs
@@ -20,7 +20,7 @@ public sealed class NotEmptyOrWhitespaceAttribute : ValidationAttribute
     public override bool IsValid(object value) => value == null || (value is string s && !string.IsNullOrWhiteSpace(s));
 
     /// <inheritdoc/>
-    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
     {
         return IsValid(value)
             ? ValidationResult.Success

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/NotEmptyOrWhitespaceAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/NotEmptyOrWhitespaceAttribute.cs
@@ -17,10 +17,10 @@ namespace Encamina.Enmarcha.Core.DataAnnotations;
 public sealed class NotEmptyOrWhitespaceAttribute : ValidationAttribute
 {
     /// <inheritdoc/>
-    public override bool IsValid(object value) => value == null || (value is string s && !string.IsNullOrWhiteSpace(s));
+    public override bool IsValid(object? value) => value == null || (value is string s && !string.IsNullOrWhiteSpace(s));
 
     /// <inheritdoc/>
-    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         return IsValid(value)
             ? ValidationResult.Success

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/RequireWhenOtherPropertyNotNullAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/RequireWhenOtherPropertyNotNullAttribute.cs
@@ -23,7 +23,7 @@ public sealed class RequireWhenOtherPropertyNotNullAttribute : ValidationAttribu
     public string OtherPropertyName { get; }
 
     /// <inheritdoc/>
-    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
     {
         var otherPropertyValue = validationContext.ObjectInstance
                                                   .GetType()

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/RequireWhenOtherPropertyNotNullAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/RequireWhenOtherPropertyNotNullAttribute.cs
@@ -23,7 +23,7 @@ public sealed class RequireWhenOtherPropertyNotNullAttribute : ValidationAttribu
     public string OtherPropertyName { get; }
 
     /// <inheritdoc/>
-    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         var otherPropertyValue = validationContext.ObjectInstance
                                                   .GetType()

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/RequireWhenOtherPropertyNotNullAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/RequireWhenOtherPropertyNotNullAttribute.cs
@@ -23,7 +23,7 @@ public sealed class RequireWhenOtherPropertyNotNullAttribute : ValidationAttribu
     public string OtherPropertyName { get; }
 
     /// <inheritdoc/>
-    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
     {
         var otherPropertyValue = validationContext.ObjectInstance
                                                   .GetType()

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/RequiredIfAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/RequiredIfAttribute.cs
@@ -33,7 +33,7 @@ public sealed class RequiredIfAttribute : ValidationAttribute
     public object ConditionalValue { get; }
 
     /// <inheritdoc/>
-    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
     {
         var conditionalValue = validationContext.ObjectInstance
             .GetType()

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/RequiredIfAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/RequiredIfAttribute.cs
@@ -33,7 +33,7 @@ public sealed class RequiredIfAttribute : ValidationAttribute
     public object ConditionalValue { get; }
 
     /// <inheritdoc/>
-    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         var conditionalValue = validationContext.ObjectInstance
             .GetType()

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/RequiredIfAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/RequiredIfAttribute.cs
@@ -33,7 +33,7 @@ public sealed class RequiredIfAttribute : ValidationAttribute
     public object ConditionalValue { get; }
 
     /// <inheritdoc/>
-    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
     {
         var conditionalValue = validationContext.ObjectInstance
             .GetType()

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/UriAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/UriAttribute.cs
@@ -34,7 +34,7 @@ public sealed class UriAttribute : DataTypeAttribute
     /// <remarks>
     /// A null value is accepted as valid since the idea of «Not Empty» doesn't necessarily means «Required».
     /// </remarks>
-    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
     {
         return IsValid(value)
             ? ValidationResult.Success

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/UriAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/UriAttribute.cs
@@ -28,13 +28,13 @@ public sealed class UriAttribute : DataTypeAttribute
     public bool AllowsNull { get; set; } = true;
 
     /// <inheritdoc/>
-    public override bool IsValid(object? value) => (AllowsNull && value == null) || (value is Uri uri && uri.IsWellFormedOriginalString());
+    public override bool IsValid(object value) => (AllowsNull && value == null) || (value is Uri uri && uri.IsWellFormedOriginalString());
 
     /// <inheritdoc/>
     /// <remarks>
     /// A null value is accepted as valid since the idea of «Not Empty» doesn't necessarily means «Required».
     /// </remarks>
-    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
     {
         return IsValid(value)
             ? ValidationResult.Success

--- a/src/Encamina.Enmarcha.Core/DataAnnotations/UriAttribute.cs
+++ b/src/Encamina.Enmarcha.Core/DataAnnotations/UriAttribute.cs
@@ -28,13 +28,13 @@ public sealed class UriAttribute : DataTypeAttribute
     public bool AllowsNull { get; set; } = true;
 
     /// <inheritdoc/>
-    public override bool IsValid(object value) => (AllowsNull && value == null) || (value is Uri uri && uri.IsWellFormedOriginalString());
+    public override bool IsValid(object? value) => (AllowsNull && value == null) || (value is Uri uri && uri.IsWellFormedOriginalString());
 
     /// <inheritdoc/>
     /// <remarks>
     /// A null value is accepted as valid since the idea of «Not Empty» doesn't necessarily means «Required».
     /// </remarks>
-    protected override ValidationResult? IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         return IsValid(value)
             ? ValidationResult.Success

--- a/src/Encamina.Enmarcha.Core/Extensions/EnumExtensions.cs
+++ b/src/Encamina.Enmarcha.Core/Extensions/EnumExtensions.cs
@@ -14,7 +14,7 @@ public static class EnumExtensions
     /// <returns>
     /// The description for the enumeration value as set with the <see cref="DescriptionAttribute"/>. If not, returns <see langword="null"/>.
     /// </returns>
-    public static string GetEnumDescription(this Enum enumValue)
+    public static string? GetEnumDescription(this Enum enumValue)
     {
         return enumValue.GetEnumDescription(false);
     }
@@ -28,12 +28,12 @@ public static class EnumExtensions
     /// </param>
     /// <returns>
     /// The description for the enumeration value as set with the <see cref="DescriptionAttribute"/>. If not, returns <see langword="null"/> unless
-    /// the <paramref name="throwIfNoDescriptionFound"/> is <see langword="true"/>, in which case this methods trows a <see cref="ArgumentException"/>.
+    /// the <paramref name="throwIfNoDescriptionFound"/> is <see langword="true"/>, in which case this methods throws a <see cref="ArgumentException"/>.
     /// </returns>
     /// <exception cref="ArgumentException">
     /// If <paramref name="throwIfNoDescriptionFound"/> is <see langword="true"/> and the enumeration value does not have a description set using the <see cref="DescriptionAttribute"/>.
     /// </exception>
-    public static string GetEnumDescription(this Enum enumValue, bool throwIfNoDescriptionFound)
+    public static string? GetEnumDescription(this Enum enumValue, bool throwIfNoDescriptionFound)
     {
         var field = enumValue.GetType().GetField(enumValue.ToString());
 

--- a/src/Encamina.Enmarcha.Core/Extensions/IConfigurationExtensions.cs
+++ b/src/Encamina.Enmarcha.Core/Extensions/IConfigurationExtensions.cs
@@ -11,7 +11,7 @@ public static class IConfigurationExtensions
     /// Checks that two instances of <see cref="IConfiguration"/> are the same configurations in terms of their settings,
     /// regardless if they are or not the same instance.
     /// </summary>
-    /// <remarks>This method might be usefull for testing scenarios.</remarks>
+    /// <remarks>This method might be useful for testing scenarios.</remarks>
     /// <param name="first">First instance of <see cref="IConfiguration"/> to check.</param>
     /// <param name="actualConfiguration">Second instance of <see cref="IConfiguration"/> to check.</param>
     /// <returns>
@@ -26,23 +26,23 @@ public static class IConfigurationExtensions
     /// Checks that an instance of <see cref="IConfiguration"/> contains the same settings as a given dictionary.
     /// </summary>
     /// <remarks>
-    /// Under the hood, an instance of <see cref="IConfiguration"/> is like a dictionary. This method might be usefull for testing scenarios.
+    /// Under the hood, an instance of <see cref="IConfiguration"/> is like a dictionary. This method might be useful for testing scenarios.
     /// </remarks>
     /// <param name="configuration">The instance of <see cref="IConfiguration"/> to check.</param>
     /// <param name="settings">The instance of a dictionary with the settings to check the configuration.</param>
     /// <returns>
     /// Returns <see langword="true"/> if the instance of <see cref="IConfiguration"/> has as settings the values from the given dictionary; otherwise returns <see langword="false"/>.
     /// </returns>
-    public static bool IsSame(this IConfiguration configuration, IDictionary<string, string> settings)
+    public static bool IsSame(this IConfiguration configuration, IDictionary<string, string?> settings)
     {
         return IsSame(configuration, settings.AsEnumerable());
     }
 
-    private static bool IsSame(IConfiguration expectedConfiguration, IEnumerable<KeyValuePair<string, string>> settings)
+    private static bool IsSame(IConfiguration expectedConfiguration, IEnumerable<KeyValuePair<string, string?>> settings)
     {
         foreach (var setting in settings)
         {
-            if (!expectedConfiguration[setting.Key].Equals(setting.Value, StringComparison.Ordinal))
+            if (!expectedConfiguration[setting.Key]!.Equals(setting.Value, StringComparison.Ordinal))
             {
                 return false;
             }

--- a/src/Encamina.Enmarcha.Core/Extensions/ObjectExtensions.cs
+++ b/src/Encamina.Enmarcha.Core/Extensions/ObjectExtensions.cs
@@ -47,29 +47,33 @@ public static class ObjectExtensions
     /// Creates a dictionary from values in an <paramref name="object"/>'s properties.
     /// Each dictionary's key will be prefixed with the name of <typeparamref name="T"/>.
     /// </summary>
-    /// <remarks>This extension method is quite usefull to create in-memory configurations.</remarks>
+    /// <remarks>This extension method is quite useful to create in-memory configurations.</remarks>
     /// <typeparam name="T">The type the object from which the dictionary will be created.</typeparam>
     /// <param name="object">The object.</param>
     /// <returns>
     /// A dictionary with values from <paramref name="object"/>'s properties as strings.
     /// </returns>
-    public static IDictionary<string, string> ToPropertyDictionary<T>(this T @object)
+    public static IDictionary<string, string?> ToPropertyDictionary<T>(this T @object)
     {
-        var dictionary = new Dictionary<string, string>();
-        var propertiesDictionary = @object.ToPropertyDictionary($@"{typeof(T).Name}:");
+        var dictionary = new Dictionary<string, string?>();
 
-        foreach (var property in propertiesDictionary)
+        if (@object is not null)
         {
-            if (property.Value is IDictionary<string, string> innerProperties)
+            var propertiesDictionary = @object.ToPropertyDictionary($@"{typeof(T).Name}:");
+
+            foreach (var property in propertiesDictionary)
             {
-                foreach (var innerProperty in innerProperties)
+                if (property.Value is IDictionary<string, string> innerProperties)
                 {
-                    dictionary.Add($@"{property.Key}:{innerProperty.Key}", innerProperty.Value);
+                    foreach (var innerProperty in innerProperties)
+                    {
+                        dictionary.Add($@"{property.Key}:{innerProperty.Key}", innerProperty.Value);
+                    }
                 }
-            }
-            else
-            {
-                dictionary.Add(property.Key, property.Value?.ToString());
+                else
+                {
+                    dictionary.Add(property.Key, property.Value?.ToString());
+                }
             }
         }
 

--- a/src/Encamina.Enmarcha.Core/Extensions/ObjectExtensions.cs
+++ b/src/Encamina.Enmarcha.Core/Extensions/ObjectExtensions.cs
@@ -26,7 +26,7 @@ public static class ObjectExtensions
     /// <returns>
     /// A dictionary with values from <paramref name="object"/>'s properties.
     /// </returns>
-    public static IDictionary<string, object> ToPropertyDictionary(this object @object, string keyPrefix)
+    public static IDictionary<string, object> ToPropertyDictionary(this object @object, string? keyPrefix)
     {
         var dictionary = new Dictionary<string, object>();
 

--- a/src/Encamina.Enmarcha.Core/Extensions/ResourceManagerExtensions.cs
+++ b/src/Encamina.Enmarcha.Core/Extensions/ResourceManagerExtensions.cs
@@ -58,7 +58,7 @@ public static class ResourceManagerExtensions
     /// The value of the resource localized from <see cref="CultureInfo.CurrentCulture"/> and formatted with replaced
     /// items from the given array of objects, or <see langword="null"/> if it cannot be found in a resource set.
     /// </returns>
-    public static string GetFormattedStringByCurrentCulture(this ResourceManager resourceManager, string resourceName, params object[] args)
+    public static string GetFormattedStringByCurrentCulture(this ResourceManager resourceManager, string resourceName, params object?[] args)
     {
         return string.Format(CultureInfo.CurrentCulture, resourceManager.GetStringByCurrentCulture(resourceName), args);
     }

--- a/src/Encamina.Enmarcha.Core/Extensions/StringExtensions.cs
+++ b/src/Encamina.Enmarcha.Core/Extensions/StringExtensions.cs
@@ -10,7 +10,7 @@ namespace Encamina.Enmarcha.Core.Extensions;
 public static class StringExtensions
 {
     /// <summary>
-    /// Normalizes a given string, removing diacritics, plus some unwanted charaters, and replacing others.
+    /// Normalizes a given string, removing diacritics, plus some unwanted characters, and replacing others.
     /// </summary>
     /// <param name="value">The <see cref="string"/> value to normalize.</param>
     /// <param name="removeCharacters">A collection of characters to remove from <paramref name="value"/>.</param>
@@ -53,7 +53,7 @@ public static class StringExtensions
     /// Removes the <c>Async</c> suffix from a string, if present.
     /// </summary>
     /// <remarks>
-    /// This extension method is usefull when manipulating a an asynchronous method or function name.
+    /// This extension method is useful when manipulating a an asynchronous method or function name.
     /// </remarks>
     /// <param name="value">The string value to remove the <c>Async</c> suffix from.</param>
     /// <returns>The value with the <c>Async</c> suffix removed, if it was present.</returns>
@@ -104,7 +104,7 @@ public static class StringExtensions
     /// </remarks>
     /// <typeparam name="T">The specific type of <paramref name="object"/>.</typeparam>
     /// <param name="template">The string to use as template.</param>
-    /// <param name="object">The object whose properties'values will be used as values for the template.</param>
+    /// <param name="object">The object whose properties values will be used as values for the template.</param>
     /// <returns>
     /// <para>
     /// A string value from the <paramref name="template"/> with values or tokens replaced with values from <paramref name="object"/>'s properties.
@@ -126,7 +126,7 @@ public static class StringExtensions
     /// <param name="templateObjectPropertiesPrefix">
     /// A value that identifies any token or parameter in the template to be replaced with values from <paramref name="object"/>'s properties is prefixed with the '<c>$</c>' character.
     /// </param>
-    /// <param name="object">The object whose properties'values will be used as values for the template.</param>
+    /// <param name="object">The object whose properties values will be used as values for the template.</param>
     /// <returns>
     /// <para>
     /// A string value from the <paramref name="template"/> with values or tokens replaced with values from <paramref name="object"/>'s properties.
@@ -144,7 +144,7 @@ public static class StringExtensions
     /// Formats a string as template with tokens or parameters provided from the values in <paramref name="templateValues"/>.
     /// </summary>
     /// <param name="template">The string to use as template.</param>
-    /// <param name="templateValues">A dictionalry with values to use as replacements for tokens or parameters in <paramref name="template"/>.</param>
+    /// <param name="templateValues">A dictionary with values to use as replacements for tokens or parameters in <paramref name="template"/>.</param>
     /// <returns>
     /// <para>
     /// A string value from the <paramref name="template"/> with values or tokens replaced with values from <paramref name="templateValues"/>'s properties.
@@ -153,7 +153,7 @@ public static class StringExtensions
     /// If <paramref name="templateValues"/> is <see langword="null"/>, then this method returns the same value as <paramref name="template"/> without any token or parameter replacement.
     /// </para>
     /// </returns>
-    public static string TemplateStringFormatterWithValues(this string template, IDictionary<string, object> templateValues)
+    public static string TemplateStringFormatterWithValues(this string template, IDictionary<string, object>? templateValues)
     {
         return templateValues == null
             ? template

--- a/src/Encamina.Enmarcha.Core/Extensions/StringExtensions.cs
+++ b/src/Encamina.Enmarcha.Core/Extensions/StringExtensions.cs
@@ -89,7 +89,7 @@ public static class StringExtensions
     /// <returns>
     /// Returns the trimmed string, or <see langword="null"/> if the trimming result is an empty string, or if <paramref name="value"/> is <see langword="null"/> or empty as well.
     /// </returns>
-    public static string TrimAndAsNullIfEmpty(this string value)
+    public static string? TrimAndAsNullIfEmpty(this string value)
     {
         var result = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 

--- a/src/Encamina.Enmarcha.Core/JsonUtils.cs
+++ b/src/Encamina.Enmarcha.Core/JsonUtils.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+﻿#pragma warning disable IDE0060 // Remove unused parameter
+
+using System.Text.Json;
 
 namespace Encamina.Enmarcha.Core;
 
@@ -7,20 +9,18 @@ namespace Encamina.Enmarcha.Core;
 /// </summary>
 public static class JsonUtils
 {
-#pragma warning disable IDE0060 // Remove unused parameter
-
     /// <summary>
     /// When using the <see cref="System.Text.Json"/> library, this method helps deserializing anonymous types from a JSON string.
     /// </summary>
     /// <remarks>
     /// The <paramref name="anonymousType"/> is required to identify the type of the anonymous type that is going to be deserialized.
     /// </remarks>
-    /// <typeparam name="T">The anonyumous type.</typeparam>
+    /// <typeparam name="T">The anonymous type.</typeparam>
     /// <param name="json">The JSON string to deserialize as an instance of an anonymous type represented by <typeparamref name="T"/>.</param>
     /// <param name="anonymousType">The anonymous type that identifies the type to deserialize from a JSON string.</param>
     /// <param name="options">A valid instance of <see cref="JsonSerializerOptions"/> with options for the deserialization.</param>
     /// <returns>A valid instance of <typeparamref name="T"/> obtained from the JSON deserialization.</returns>
-    public static T DeserializeAnonymousType<T>(string json, T anonymousType, JsonSerializerOptions? options = default) => JsonSerializer.Deserialize<T>(json, options);
+    public static T? DeserializeAnonymousType<T>(string json, T anonymousType, JsonSerializerOptions? options = default) => JsonSerializer.Deserialize<T>(json, options);
+}
 
 #pragma warning restore IDE0060
-}

--- a/src/Encamina.Enmarcha.Core/JsonUtils.cs
+++ b/src/Encamina.Enmarcha.Core/JsonUtils.cs
@@ -20,7 +20,7 @@ public static class JsonUtils
     /// <param name="anonymousType">The anonymous type that identifies the type to deserialize from a JSON string.</param>
     /// <param name="options">A valid instance of <see cref="JsonSerializerOptions"/> with options for the deserialization.</param>
     /// <returns>A valid instance of <typeparamref name="T"/> obtained from the JSON deserialization.</returns>
-    public static T DeserializeAnonymousType<T>(string json, T anonymousType, JsonSerializerOptions options = default) => JsonSerializer.Deserialize<T>(json, options);
+    public static T DeserializeAnonymousType<T>(string json, T anonymousType, JsonSerializerOptions? options = default) => JsonSerializer.Deserialize<T>(json, options);
 
 #pragma warning restore IDE0060
 }


### PR DESCRIPTION
- Fixed CS8765 warnings in various files (GuidNotEmptyAttribute.cs, NotEmptyOrWhitespaceAttribute.cs, RequireWhenOtherPropertyNotNullAttribute.cs, RequiredIfAttribute.cs, UriAttribute.cs) by addressing potential null objects and the chance of ValidationResult returning null.
- Resolved CS8603 warning in EnumExtensions.cs by specifying that GetEnumDescription could return null. Additionally, code cleanup.
- Fixed CS8602 warning in IConfigurationExtensions.cs by ensuring that expectedConfiguration[setting.key] would never be null. Furthermore, fixed CS8620 warnings by acknowledging that IEnumerable<KeyValuePair<string, string>> and IDictionary<string, string> values could be null.
- Corrected CS8625 warning in ObjectExtensions.cs by indicating that the keyPrefix string might be null. Also, resolved CS8619 and CS8604 warnings by ensuring that if object is not null, a dictionary is created with possible null values, else, an empty dictionary is returned.
- Fixed CS8603 warning in ResourceManagerExtensions.cs by specifying that GetFormattedStringByCurrentCulture might have nullable params.
- Resolved CS8603 warning in StringExtensions.cs by indicating that TrimAndAsNullIfEmpty could return null and fixed CS8604 warning to allow TemplateStringFormatterWithValues to accept a null dictionary. Additionally, code cleanup.
- Fixed warning CS803 in JsonUtils.cs by adding that DeserializeAnonymousType can return null. Additionally, code cleanup.