### PR TITLE
Fix some warnings in Encamina.Enmarcha.Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Previous classification is not required if changes are simple or all belong to t
   - `Encamina.Enmarcha.AspNet`
   - `Encamina.Enmarcha.Bot`
   - `Encamina.Enmarcha.Core`
+  - `Encamina.Enmarcha.Data`
  
 ## [8.1.5]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.6</VersionPrefix>
-    <VersionSuffix>preview-10</VersionSuffix>
+    <VersionSuffix>preview-11</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Core/Extensions/ObjectExtensions.cs
+++ b/src/Encamina.Enmarcha.Core/Extensions/ObjectExtensions.cs
@@ -47,7 +47,7 @@ public static class ObjectExtensions
     /// Creates a dictionary from values in an <paramref name="object"/>'s properties.
     /// Each dictionary's key will be prefixed with the name of <typeparamref name="T"/>.
     /// </summary>
-    /// <remarks>This extension method is quite usefull to create in-memory configurations.</remarks>
+    /// <remarks>This extension method is quite useful to create in-memory configurations.</remarks>
     /// <typeparam name="T">The type the object from which the dictionary will be created.</typeparam>
     /// <param name="object">The object.</param>
     /// <returns>

--- a/src/Encamina.Enmarcha.Core/Extensions/ResourceManagerExtensions.cs
+++ b/src/Encamina.Enmarcha.Core/Extensions/ResourceManagerExtensions.cs
@@ -74,7 +74,7 @@ public static class ResourceManagerExtensions
     /// The value of the resource localized from <see cref="CultureInfo.CurrentUICulture"/> and formatted with replaced
     /// items from the given array of objects, or <see langword="null"/> if it cannot be found in a resource set.
     /// </returns>
-    public static string GetFormattedStringByCurrentUICulture(this ResourceManager resourceManager, string resourceName, params object[] args)
+    public static string GetFormattedStringByCurrentUICulture(this ResourceManager resourceManager, string resourceName, params object?[] args)
     {
         return string.Format(CultureInfo.CurrentUICulture, resourceManager.GetStringByCurrentUICulture(resourceName), args);
     }

--- a/src/Encamina.Enmarcha.Data.Abstractions/IAsyncReadRepository.cs
+++ b/src/Encamina.Enmarcha.Data.Abstractions/IAsyncReadRepository.cs
@@ -32,5 +32,5 @@ public interface IAsyncReadRepository<TEntity>
     /// <param name="id">The entity's unique identifier.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>An entity from the repository.</returns>
-    Task<TEntity> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken);
+    Task<TEntity?> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken);
 }

--- a/src/Encamina.Enmarcha.Data.Abstractions/IReadRepository.cs
+++ b/src/Encamina.Enmarcha.Data.Abstractions/IReadRepository.cs
@@ -29,5 +29,5 @@ public interface IReadRepository<TEntity>
     /// <typeparam name="TEntityId">The specific type of the entity's unique identifier.</typeparam>
     /// <param name="id">The entity's unique identifier.</param>
     /// <returns>An entity from the repository.</returns>
-    TEntity GetById<TEntityId>(TEntityId id);
+    TEntity? GetById<TEntityId>(TEntityId id);
 }

--- a/src/Encamina.Enmarcha.Data.Cosmos/CosmosRepository{T}.cs
+++ b/src/Encamina.Enmarcha.Data.Cosmos/CosmosRepository{T}.cs
@@ -68,7 +68,7 @@ internal sealed class CosmosRepository<T> : ICosmosRepository<T>
     /// <inheritdoc/>
     public async Task AddOrUpdateBulkAsync(IEnumerable<T> entities, CancellationToken cancellationToken)
     {
-        Task aggregationTask = null;
+        Task? aggregationTask = null;
 
         try
         {
@@ -309,7 +309,7 @@ internal sealed class CosmosRepository<T> : ICosmosRepository<T>
     }
 
     /// <inheritdoc/>
-    public async Task<T?> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken) => await GetByIdAsync(id.ToString(), null, cancellationToken);
+    public async Task<T?> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken) => await GetByIdAsync(id!.ToString(), null, cancellationToken);
 
     /// <inheritdoc/>
     public async Task AddAsync(T entity, CancellationToken cancellationToken) => await AddOrUpdateAsync(entity, cancellationToken);
@@ -323,7 +323,7 @@ internal sealed class CosmosRepository<T> : ICosmosRepository<T>
     /// </remarks>
     public async Task DeleteAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken)
     {
-        var partitionKey = GeneratePartition(id is string idString ? idString : id.ToString());
+        var partitionKey = GeneratePartition(id is string idString ? idString : id!.ToString());
 
         var resultSet = container.GetItemQueryIterator<CosmosDbItem>(new QueryDefinition(@"SELECT c.id FROM c"), requestOptions: new QueryRequestOptions()
         {

--- a/src/Encamina.Enmarcha.Data.Cosmos/CosmosRepository{T}.cs
+++ b/src/Encamina.Enmarcha.Data.Cosmos/CosmosRepository{T}.cs
@@ -195,7 +195,7 @@ internal sealed class CosmosRepository<T> : ICosmosRepository<T>
     }
 
     /// <inheritdoc/>
-    public async Task<T> GetByIdAsync(string entityId, string partitionKey, CancellationToken cancellationToken)
+    public async Task<T?> GetByIdAsync(string entityId, string partitionKey, CancellationToken cancellationToken)
     {
         try
         {
@@ -309,7 +309,7 @@ internal sealed class CosmosRepository<T> : ICosmosRepository<T>
     }
 
     /// <inheritdoc/>
-    public async Task<T> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken) => await GetByIdAsync(id.ToString(), null, cancellationToken);
+    public async Task<T?> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken) => await GetByIdAsync(id.ToString(), null, cancellationToken);
 
     /// <inheritdoc/>
     public async Task AddAsync(T entity, CancellationToken cancellationToken) => await AddOrUpdateAsync(entity, cancellationToken);

--- a/src/Encamina.Enmarcha.Data.Cosmos/CosmosRepository{T}.cs
+++ b/src/Encamina.Enmarcha.Data.Cosmos/CosmosRepository{T}.cs
@@ -195,7 +195,7 @@ internal sealed class CosmosRepository<T> : ICosmosRepository<T>
     }
 
     /// <inheritdoc/>
-    public async Task<T?> GetByIdAsync(string entityId, string partitionKey, CancellationToken cancellationToken)
+    public async Task<T?> GetByIdAsync(string entityId, string? partitionKey, CancellationToken cancellationToken)
     {
         try
         {
@@ -360,7 +360,7 @@ internal sealed class CosmosRepository<T> : ICosmosRepository<T>
         return (result.AsQueryable(), continuation);
     }
 
-    private static PartitionKey GeneratePartition(string partitionKey)
+    private static PartitionKey GeneratePartition(string? partitionKey)
     {
         return string.IsNullOrWhiteSpace(partitionKey)
             ? throw new ArgumentNullException(nameof(partitionKey))

--- a/src/Encamina.Enmarcha.Data.Cosmos/ICosmosRepository{T}.cs
+++ b/src/Encamina.Enmarcha.Data.Cosmos/ICosmosRepository{T}.cs
@@ -144,7 +144,7 @@ public interface ICosmosRepository<T> : IAsyncRepository<T>
     /// <param name="partitionKey">The partition key of the entity to retrieve.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>The retrieved entity contained within a <see cref="Task"/> object representing the service response for the asynchronous operation.</returns>
-    Task<T?> GetByIdAsync(string entityId, string partitionKey, CancellationToken cancellationToken);
+    Task<T?> GetByIdAsync(string entityId, string? partitionKey, CancellationToken cancellationToken);
 
     /// <summary>
     /// Read all items (entities) from a given partition key.

--- a/src/Encamina.Enmarcha.Data.Cosmos/ICosmosRepository{T}.cs
+++ b/src/Encamina.Enmarcha.Data.Cosmos/ICosmosRepository{T}.cs
@@ -1,10 +1,10 @@
-﻿using System.Linq.Expressions;
+﻿#pragma warning disable S2360 // Optional parameters should not be used
+
+using System.Linq.Expressions;
 
 using Encamina.Enmarcha.Data.Abstractions;
 
 namespace Encamina.Enmarcha.Data.Cosmos;
-
-#pragma warning disable S2360 // Optional parameters should not be used
 
 /// <summary>
 /// Represents a repository pattern adapted for Azure Cosmos DB.
@@ -144,7 +144,7 @@ public interface ICosmosRepository<T> : IAsyncRepository<T>
     /// <param name="partitionKey">The partition key of the entity to retrieve.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>The retrieved entity contained within a <see cref="Task"/> object representing the service response for the asynchronous operation.</returns>
-    Task<T> GetByIdAsync(string entityId, string partitionKey, CancellationToken cancellationToken);
+    Task<T?> GetByIdAsync(string entityId, string partitionKey, CancellationToken cancellationToken);
 
     /// <summary>
     /// Read all items (entities) from a given partition key.

--- a/src/Encamina.Enmarcha.Data.EntityFramework/AsyncReadRepositoryBase.cs
+++ b/src/Encamina.Enmarcha.Data.EntityFramework/AsyncReadRepositoryBase.cs
@@ -43,5 +43,5 @@ public abstract class AsyncReadRepositoryBase<TEntity> : IAsyncReadRepository<TE
 
     /// <inheritdoc/>
     public virtual async Task<TEntity?> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken)
-        => await dbContext.GetSet<TEntity>().FindAsync(new object[] { id }, cancellationToken);
+        => await dbContext.GetSet<TEntity>().FindAsync(new object?[] { id }, cancellationToken);
 }

--- a/src/Encamina.Enmarcha.Data.EntityFramework/AsyncReadRepositoryBase.cs
+++ b/src/Encamina.Enmarcha.Data.EntityFramework/AsyncReadRepositoryBase.cs
@@ -42,6 +42,6 @@ public abstract class AsyncReadRepositoryBase<TEntity> : IAsyncReadRepository<TE
     }
 
     /// <inheritdoc/>
-    public virtual async Task<TEntity> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken)
+    public virtual async Task<TEntity?> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken)
         => await dbContext.GetSet<TEntity>().FindAsync(new object[] { id }, cancellationToken);
 }

--- a/src/Encamina.Enmarcha.Data.EntityFramework/AsyncRepositoryBase.cs
+++ b/src/Encamina.Enmarcha.Data.EntityFramework/AsyncRepositoryBase.cs
@@ -5,8 +5,6 @@ using CommunityToolkit.Diagnostics;
 using Encamina.Enmarcha.Data.Abstractions;
 using Encamina.Enmarcha.Data.EntityFramework.Internals;
 
-using Encamina.Enmarcha.Entities.Abstractions;
-
 using Microsoft.EntityFrameworkCore;
 
 namespace Encamina.Enmarcha.Data.EntityFramework;
@@ -14,7 +12,7 @@ namespace Encamina.Enmarcha.Data.EntityFramework;
 /// <summary>
 /// Base class for asynchronous repositories powered by Entity Framework.
 /// </summary>
-/// <typeparam name="TEntity">The type of (data) entity handled by this asychronous repository.</typeparam>
+/// <typeparam name="TEntity">The type of (data) entity handled by this asynchronous repository.</typeparam>
 [SuppressMessage("Minor Code Smell", "S1694:An abstract class should have both abstract and concrete methods", Justification = "It's the Architecture's intent that this class must be inherited!")]
 public abstract class AsyncRepositoryBase<TEntity> : IAsyncRepository<TEntity> where TEntity : class
 {
@@ -50,5 +48,5 @@ public abstract class AsyncRepositoryBase<TEntity> : IAsyncRepository<TEntity> w
         => await readRepository.GetAllAsync(queryFunction, cancellationToken);
 
     /// <inheritdoc/>
-    public virtual async Task<TEntity> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken) => await readRepository.GetByIdAsync(id, cancellationToken);
+    public virtual async Task<TEntity?> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken) => await readRepository.GetByIdAsync(id, cancellationToken);
 }

--- a/src/Encamina.Enmarcha.Data.EntityFramework/AsyncWriteRepositoryBase.cs
+++ b/src/Encamina.Enmarcha.Data.EntityFramework/AsyncWriteRepositoryBase.cs
@@ -54,7 +54,7 @@ public abstract class AsyncWriteRepositoryBase<TEntity> : IAsyncWriteRepository<
     {
         var set = dbContext.GetSet<TEntity>();
 
-        var entity = await set.FindAsync(new object[] { id }, cancellationToken);
+        var entity = await set.FindAsync(new object?[] { id }, cancellationToken);
 
         if (entity != null)
         {

--- a/src/Encamina.Enmarcha.Data.EntityFramework/FullRepositoryBase.cs
+++ b/src/Encamina.Enmarcha.Data.EntityFramework/FullRepositoryBase.cs
@@ -71,10 +71,10 @@ public abstract class FullRepositoryBase<TEntity> : IFullRepository<TEntity> whe
         => await repositoryAsync.GetAllAsync(queryFunction, cancellationToken);
 
     /// <inheritdoc/>
-    public virtual TEntity GetById<TEntityId>(TEntityId id) => repository.GetById(id);
+    public virtual TEntity? GetById<TEntityId>(TEntityId id) => repository.GetById(id);
 
     /// <inheritdoc/>
-    public virtual async Task<TEntity> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken) => await repositoryAsync.GetByIdAsync(id, cancellationToken);
+    public virtual async Task<TEntity?> GetByIdAsync<TEntityId>(TEntityId id, CancellationToken cancellationToken) => await repositoryAsync.GetByIdAsync(id, cancellationToken);
 
     /// <inheritdoc/>
     public virtual void Update(TEntity entity) => repository.Update(entity);

--- a/src/Encamina.Enmarcha.Data.EntityFramework/ReadRepositoryBase.cs
+++ b/src/Encamina.Enmarcha.Data.EntityFramework/ReadRepositoryBase.cs
@@ -46,5 +46,5 @@ public abstract class ReadRepositoryBase<TEntity> : IReadRepository<TEntity> whe
     }
 
     /// <inheritdoc/>
-    public TEntity GetById<TEntityId>(TEntityId id) => dbContext.GetSet<TEntity>().Find(id);
+    public TEntity? GetById<TEntityId>(TEntityId id) => dbContext.GetSet<TEntity>().Find(id);
 }

--- a/src/Encamina.Enmarcha.Data.EntityFramework/RepositoryBase.cs
+++ b/src/Encamina.Enmarcha.Data.EntityFramework/RepositoryBase.cs
@@ -5,8 +5,6 @@ using CommunityToolkit.Diagnostics;
 using Encamina.Enmarcha.Data.Abstractions;
 using Encamina.Enmarcha.Data.EntityFramework.Internals;
 
-using Encamina.Enmarcha.Entities.Abstractions;
-
 using Microsoft.EntityFrameworkCore;
 
 namespace Encamina.Enmarcha.Data.EntityFramework;
@@ -14,7 +12,7 @@ namespace Encamina.Enmarcha.Data.EntityFramework;
 /// <summary>
 /// Base class for a repositories powered by Entity Framework.
 /// </summary>
-/// <typeparam name="TEntity">The type of (data) entity handled by this asychronous repository.</typeparam>
+/// <typeparam name="TEntity">The type of (data) entity handled by this asynchronous repository.</typeparam>
 [SuppressMessage("Minor Code Smell", "S1694:An abstract class should have both abstract and concrete methods", Justification = "It's the Architecture's intent that this class must be inherited!")]
 public abstract class RepositoryBase<TEntity> : IRepository<TEntity> where TEntity : class
 {
@@ -55,7 +53,7 @@ public abstract class RepositoryBase<TEntity> : IRepository<TEntity> where TEnti
     public virtual IQueryable<TEntity> GetAll([NotNull] Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFunction) => readRepository.GetAll(queryFunction);
 
     /// <inheritdoc/>
-    public virtual TEntity GetById<TEntityId>(TEntityId id) => readRepository.GetById(id);
+    public virtual TEntity? GetById<TEntityId>(TEntityId id) => readRepository.GetById(id);
 
     /// <inheritdoc/>
     public virtual void Update(TEntity entity) => writeRepository.Update(entity);


### PR DESCRIPTION
- Fixed CS8604 warnings in ResourceManagerExtensions.cs, allowing for the possibility of null params.
- Resolved CS8604 warnings in ResourceManagerExtensions.cs by specifying that the "params" parameter of the GetFormattedStringByCurrentUICulture method could be null.
- Fixed CS8600 warning in CosmosRepository{T}.cs by indicating that aggregationTask in the AddOrUpdateBulkAsync method could be null. Additionally, GetByIdAsync method was adjusted to adhere to the interface signature. CS8602 warnings in some GetByIdAsync were also resolved by specifying that TEntity id cannot be null, ensuring safe .ToString() operations. Furthermore, GeneratePartition method was updated to accept a null string.
- AsyncReadRepositoryBase.cs, AsyncRepositoryBase.cs, FullRepositoryBase.cs, ReadRepositoryBase.cs, and RepositoryBase.cs were updated to comply with the interface method signature.
- AsyncWriteRepositoryBase.cs was adjusted to resolve a CS8604 warning in the FindAsync method, clarifying its ability to handle an array of null objects.
- General code cleanup was performed.