### PR TITLE
Fixed some warnings in Encamina.Enmarcha.Email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Previous classification is not required if changes are simple or all belong to t
   - `Encamina.Enmarcha.Bot`
   - `Encamina.Enmarcha.Core`
   - `Encamina.Enmarcha.Data`
+  - `Encamina.Enmarcha.Email`
  
 ## [8.1.5]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.6</VersionPrefix>
-    <VersionSuffix>preview-11</VersionSuffix>
+    <VersionSuffix>preview-12</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/ModelInfo.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/ModelInfo.cs
@@ -20,7 +20,7 @@ public sealed class ModelInfo
         { @"gpt-4", new ModelInfo() { Id = @"gpt-4", MaxTokens = 8192, Encoding = @"cl100k_base", IsObsolete = false } },
         { @"gpt-4-32k", new ModelInfo() { Id = @"gpt-4", MaxTokens = 32768, Encoding = @"cl100k_base", IsObsolete = false } },
         { @"gpt-4-turbo", new ModelInfo() { Id = @"gpt-4", MaxTokens = 128000, Encoding = @"cl100k_base", IsObsolete = false } },
-        { @"gpt-4o", new ModelInfo() { Id = @"gpt-4", MaxTokens = 128000, Encoding = @"o200k_base", IsObsolete = false } },
+        { @"gpt-4o", new ModelInfo() { Id = @"gpt-4o", MaxTokens = 128000, Encoding = @"o200k_base", IsObsolete = false } },
         { @"text-davinci-001", new ModelInfo() { Id = @"text-davinci-001", MaxTokens = 2049, Encoding = @"r50k_base", IsObsolete = true } },
         { @"text-davinci-002", new ModelInfo() { Id = @"text-davinci-002", MaxTokens = 4097, Encoding = @"p50k_base", IsObsolete = true } },
         { @"text-davinci-003", new ModelInfo() { Id = @"text-davinci-003", MaxTokens = 4097, Encoding = @"p50k_base", IsObsolete = true } },

--- a/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/ModelInfo.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/ModelInfo.cs
@@ -20,6 +20,7 @@ public sealed class ModelInfo
         { @"gpt-4", new ModelInfo() { Id = @"gpt-4", MaxTokens = 8192, Encoding = @"cl100k_base", IsObsolete = false } },
         { @"gpt-4-32k", new ModelInfo() { Id = @"gpt-4", MaxTokens = 32768, Encoding = @"cl100k_base", IsObsolete = false } },
         { @"gpt-4-turbo", new ModelInfo() { Id = @"gpt-4", MaxTokens = 128000, Encoding = @"cl100k_base", IsObsolete = false } },
+        { @"gpt-4o", new ModelInfo() { Id = @"gpt-4", MaxTokens = 128000, Encoding = @"o200k_base", IsObsolete = false } },
         { @"text-davinci-001", new ModelInfo() { Id = @"text-davinci-001", MaxTokens = 2049, Encoding = @"r50k_base", IsObsolete = true } },
         { @"text-davinci-002", new ModelInfo() { Id = @"text-davinci-002", MaxTokens = 4097, Encoding = @"p50k_base", IsObsolete = true } },
         { @"text-davinci-003", new ModelInfo() { Id = @"text-davinci-003", MaxTokens = 4097, Encoding = @"p50k_base", IsObsolete = true } },

--- a/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/ModelInfo.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/ModelInfo.cs
@@ -20,7 +20,6 @@ public sealed class ModelInfo
         { @"gpt-4", new ModelInfo() { Id = @"gpt-4", MaxTokens = 8192, Encoding = @"cl100k_base", IsObsolete = false } },
         { @"gpt-4-32k", new ModelInfo() { Id = @"gpt-4", MaxTokens = 32768, Encoding = @"cl100k_base", IsObsolete = false } },
         { @"gpt-4-turbo", new ModelInfo() { Id = @"gpt-4", MaxTokens = 128000, Encoding = @"cl100k_base", IsObsolete = false } },
-        { @"gpt-4o", new ModelInfo() { Id = @"gpt-4", MaxTokens = 128000, Encoding = @"o200k_base", IsObsolete = false } },
         { @"text-davinci-001", new ModelInfo() { Id = @"text-davinci-001", MaxTokens = 2049, Encoding = @"r50k_base", IsObsolete = true } },
         { @"text-davinci-002", new ModelInfo() { Id = @"text-davinci-002", MaxTokens = 4097, Encoding = @"p50k_base", IsObsolete = true } },
         { @"text-davinci-003", new ModelInfo() { Id = @"text-davinci-003", MaxTokens = 4097, Encoding = @"p50k_base", IsObsolete = true } },

--- a/src/Encamina.Enmarcha.Email.Abstractions/EmailAttachmentSpecification.cs
+++ b/src/Encamina.Enmarcha.Email.Abstractions/EmailAttachmentSpecification.cs
@@ -10,12 +10,12 @@ public class EmailAttachmentSpecification
     /// <summary>
     /// Gets the file name of the attachment in this specification.
     /// </summary>
-    public string FileName { get; init; }
+    public string? FileName { get; init; }
 
     /// <summary>
     /// Gets the <see cref="ContentType">content type</see> of the attachment in this specification.
     /// </summary>
-    public ContentType ContentType { get; init; }
+    public ContentType? ContentType { get; init; }
 
     /// <summary>
     /// Gets the binary data of the attachment in this specification.

--- a/src/Encamina.Enmarcha.Email.Abstractions/EmailAttachmentSpecification.cs
+++ b/src/Encamina.Enmarcha.Email.Abstractions/EmailAttachmentSpecification.cs
@@ -10,7 +10,7 @@ public class EmailAttachmentSpecification
     /// <summary>
     /// Gets the file name of the attachment in this specification.
     /// </summary>
-    public string? FileName { get; init; }
+    public string FileName { get; init; }
 
     /// <summary>
     /// Gets the <see cref="ContentType">content type</see> of the attachment in this specification.

--- a/src/Encamina.Enmarcha.Email.Abstractions/EmailAttachmentSpecification.cs
+++ b/src/Encamina.Enmarcha.Email.Abstractions/EmailAttachmentSpecification.cs
@@ -10,7 +10,7 @@ public class EmailAttachmentSpecification
     /// <summary>
     /// Gets the file name of the attachment in this specification.
     /// </summary>
-    public string FileName { get; init; }
+    public string? FileName { get; init; }
 
     /// <summary>
     /// Gets the <see cref="ContentType">content type</see> of the attachment in this specification.

--- a/src/Encamina.Enmarcha.Email.Abstractions/EmailSpecification.cs
+++ b/src/Encamina.Enmarcha.Email.Abstractions/EmailSpecification.cs
@@ -28,7 +28,7 @@ public class EmailSpecification
     /// <summary>
     /// Gets or sets the e-mail body.
     /// </summary>
-    public string Body { get; set; }
+    public string? Body { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the <see cref="Body">body</see> of the e-mail is an HTML or not.

--- a/src/Encamina.Enmarcha.Email.Abstractions/IEmailBuilder.cs
+++ b/src/Encamina.Enmarcha.Email.Abstractions/IEmailBuilder.cs
@@ -1,9 +1,9 @@
-﻿using System.Net.Mime;
+﻿#pragma warning disable S2360 // Optional parameters should not be used
+
+using System.Net.Mime;
 using System.Text;
 
 namespace Encamina.Enmarcha.Email.Abstractions;
-
-#pragma warning disable S2360 // Optional parameters should not be used
 
 /// <summary>
 /// Represents a builder that allows creating and sending a new e-mail.

--- a/src/Encamina.Enmarcha.Email.Abstractions/IEmailBuilder.cs
+++ b/src/Encamina.Enmarcha.Email.Abstractions/IEmailBuilder.cs
@@ -38,7 +38,7 @@ public interface IEmailBuilder
     /// </summary>
     /// <param name="senderName">Optional (custom) sender name.</param>
     /// <returns>The <see cref="IEmailBuilder"/> so that additional calls can be chained.</returns>
-    IEmailBuilder SetDefaultSender(string senderName = null);
+    IEmailBuilder SetDefaultSender(string? senderName = null);
 
     /// <summary>
     /// Adds an attachment.
@@ -73,7 +73,7 @@ public interface IEmailBuilder
     /// <param name="recipientName">The recipient's name. Defaults to <see langword="null"/>.</param>
     /// <param name="recipientType">The type of recipient (like 'to', 'cc', or 'bcc'). Defaults to <see cref="EmailRecipientType.TO"/>.</param>
     /// <returns>The <see cref="IEmailBuilder"/> so that additional calls can be chained.</returns>
-    IEmailBuilder AddRecipient(string emailAddress, string recipientName = null, EmailRecipientType recipientType = EmailRecipientType.TO);
+    IEmailBuilder AddRecipient(string emailAddress, string? recipientName = null, EmailRecipientType recipientType = EmailRecipientType.TO);
 
     /// <summary>
     /// Sets the e-mail's subject.

--- a/src/Encamina.Enmarcha.Email.Abstractions/SmtpClientOptions.cs
+++ b/src/Encamina.Enmarcha.Email.Abstractions/SmtpClientOptions.cs
@@ -6,7 +6,7 @@ using Encamina.Enmarcha.Entities.Abstractions;
 namespace Encamina.Enmarcha.Email.Abstractions;
 
 /// <summary>
-/// Represent's common SMTP configuration parameters or options.
+/// Represents common SMTP configuration parameters or options.
 /// </summary>
 public class SmtpClientOptions : INameable
 {

--- a/src/Encamina.Enmarcha.Email.Abstractions/SmtpClientOptions.cs
+++ b/src/Encamina.Enmarcha.Email.Abstractions/SmtpClientOptions.cs
@@ -10,7 +10,7 @@ namespace Encamina.Enmarcha.Email.Abstractions;
 /// </summary>
 public class SmtpClientOptions : INameable
 {
-    private string name = null;
+    private string? name = null;
 
     /// <summary>
     /// Gets or sets the host name of the SMTP service.

--- a/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
@@ -156,7 +156,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
         return this;
     }
 
-    private static SmtpClientOptions ValidateOptions(SmtpClientOptions? smtpClientOptions)
+    private static SmtpClientOptions ValidateOptions(SmtpClientOptions smtpClientOptions)
     {
 #pragma warning disable S3236 // Caller information arguments should not be provided explicitly
         Guard.IsNotNull(smtpClientOptions);

--- a/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
@@ -27,7 +27,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
     /// <param name="smtpClientOptions">Options for SMTP client.</param>
     public EmailService(IOptions<SmtpClientOptions> smtpClientOptions)
     {
-        SmtpClientOptions = ValidateOptions(smtpClientOptions?.Value);
+        SmtpClientOptions = ValidateOptions(smtpClientOptions.Value);
     }
 
     /// <inheritdoc/>
@@ -56,7 +56,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
         {
             ContentType = contentType,
             Data = data,
-            FileName = fileName?.Trim(),
+            FileName = fileName.Trim(),
         });
 
         return this;
@@ -156,7 +156,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
         return this;
     }
 
-    private static SmtpClientOptions ValidateOptions(SmtpClientOptions? smtpClientOptions)
+    private static SmtpClientOptions ValidateOptions(SmtpClientOptions smtpClientOptions)
     {
 #pragma warning disable S3236 // Caller information arguments should not be provided explicitly
         Guard.IsNotNull(smtpClientOptions);

--- a/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
@@ -56,7 +56,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
         {
             ContentType = contentType,
             Data = data,
-            FileName = fileName.Trim(),
+            FileName = fileName?.Trim(),
         });
 
         return this;

--- a/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
@@ -56,7 +56,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
         {
             ContentType = contentType,
             Data = data,
-            FileName = fileName?.Trim(),
+            FileName = fileName.Trim(),
         });
 
         return this;

--- a/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
@@ -27,7 +27,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
     /// <param name="smtpClientOptions">Options for SMTP client.</param>
     public EmailService(IOptions<SmtpClientOptions> smtpClientOptions)
     {
-        SmtpClientOptions = ValidateOptions(smtpClientOptions.Value);
+        SmtpClientOptions = ValidateOptions(smtpClientOptions?.Value);
     }
 
     /// <inheritdoc/>
@@ -56,7 +56,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
         {
             ContentType = contentType,
             Data = data,
-            FileName = fileName.Trim(),
+            FileName = fileName?.Trim(),
         });
 
         return this;
@@ -156,7 +156,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
         return this;
     }
 
-    private static SmtpClientOptions ValidateOptions(SmtpClientOptions smtpClientOptions)
+    private static SmtpClientOptions ValidateOptions(SmtpClientOptions? smtpClientOptions)
     {
 #pragma warning disable S3236 // Caller information arguments should not be provided explicitly
         Guard.IsNotNull(smtpClientOptions);

--- a/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
@@ -63,7 +63,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
     }
 
     /// <inheritdoc/>
-    public IEmailBuilder AddRecipient(string emailAddress, string recipientName = null, EmailRecipientType recipientType = EmailRecipientType.TO)
+    public IEmailBuilder AddRecipient(string emailAddress, string? recipientName = null, EmailRecipientType recipientType = EmailRecipientType.TO)
     {
         Guard.IsNotNullOrWhiteSpace(emailAddress);
 
@@ -128,7 +128,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
     public IEmailBuilder SetSender(string emailAddress) => SetSender(emailAddress, null);
 
     /// <inheritdoc/>
-    public IEmailBuilder SetSender(string emailAddress, string senderName)
+    public IEmailBuilder SetSender(string emailAddress, string? senderName)
     {
         Guard.IsNotNullOrWhiteSpace(emailAddress);
         Guard.IsTrue(emailAddress.IsValidEmail(), nameof(emailAddress), @"Parameter is not a valid e-mail format!");
@@ -143,7 +143,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
     }
 
     /// <inheritdoc/>
-    public IEmailBuilder SetDefaultSender(string senderName = null) => SetSender(SmtpClientOptions.User, senderName);
+    public IEmailBuilder SetDefaultSender(string? senderName = null) => SetSender(SmtpClientOptions.User, senderName);
 
     /// <inheritdoc/>
     /// <remarks>This implementation does not allows the subject to be <see langword="null"/>.</remarks>

--- a/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
@@ -50,7 +50,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
         => AddAttachment(fileName, data, string.IsNullOrWhiteSpace(contentTypeValue) ? null : new ContentType(contentTypeValue));
 
     /// <inheritdoc/>
-    public IEmailBuilder AddAttachment(string fileName, byte[] data, ContentType contentType)
+    public IEmailBuilder AddAttachment(string fileName, byte[] data, ContentType? contentType)
     {
         Specification.Attachments.Add(new EmailAttachmentSpecification()
         {
@@ -114,7 +114,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
     }
 
     /// <inheritdoc/>
-    public IEmailBuilder SetBody(string body, bool isHtml = false)
+    public IEmailBuilder SetBody(string? body, bool isHtml = false)
     {
         Specification.Body = body;
         Specification.IsHtmlBody = isHtml;
@@ -156,7 +156,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
         return this;
     }
 
-    private static SmtpClientOptions ValidateOptions(SmtpClientOptions smtpClientOptions)
+    private static SmtpClientOptions ValidateOptions(SmtpClientOptions? smtpClientOptions)
     {
 #pragma warning disable S3236 // Caller information arguments should not be provided explicitly
         Guard.IsNotNull(smtpClientOptions);

--- a/src/Encamina.Enmarcha.Email.MailKit/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/Extensions/IServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ public static class IServiceCollectionExtensions
     /// <seealso href="http://www.mimekit.net/"/>
     public static IServiceCollection AddMailKitEmailProvider(this IServiceCollection services, IConfiguration configuration, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
     {
-        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration.GetSection(nameof(SmtpClientOptions))).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
+        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration?.GetSection(nameof(SmtpClientOptions))).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public static class IServiceCollectionExtensions
     /// <seealso href="http://www.mimekit.net/"/>
     public static IServiceCollection AddMailKitEmailProvider(this IServiceCollection services, IConfiguration configuration, Action<SmtpClientOptions> options, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
     {
-        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration.GetSection(nameof(SmtpClientOptions))).PostConfigure(options).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
+        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration?.GetSection(nameof(SmtpClientOptions))).PostConfigure(options).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
     }
 
     private static IServiceCollection InnerAddMailKitEmailProvider(this IServiceCollection services, Action<OptionsBuilder<SmtpClientOptions>> setupOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)

--- a/src/Encamina.Enmarcha.Email.MailKit/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/Extensions/IServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Encamina.Enmarcha.Email.Abstractions;
+﻿#pragma warning disable S2360 // Optional parameters should not be used
+
+using Encamina.Enmarcha.Email.Abstractions;
 using Encamina.Enmarcha.Email.MailKit;
 
 using Microsoft.Extensions.Configuration;
@@ -6,8 +8,6 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
-
-#pragma warning disable S2360 // Optional parameters should not be used
 
 /// <summary>
 /// Extension methods for configuring common and required services e-mail management using <see href="https://github.com/jstedfast/MailKit">MailKit.</see>.
@@ -22,12 +22,12 @@ public static class IServiceCollectionExtensions
     /// <remarks>Adds the <see cref="IEmailProviderFactory"/> to retrieve instances of <see cref="IEmailProvider"/> in the given <paramref name="serviceLifetime">service lifetime</paramref>.</remarks>
     /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="configuration">The current set of key-value application configuration parameters.</param>
-    /// <param name="serviceLifetime">The lifetime for the e-mail proider service. By default it is <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <param name="serviceLifetime">The lifetime for the e-mail provider service. By default it is <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     /// <seealso href="http://www.mimekit.net/"/>
     public static IServiceCollection AddMailKitEmailProvider(this IServiceCollection services, IConfiguration configuration, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
     {
-        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration?.GetSection(nameof(SmtpClientOptions))).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
+        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration.GetSection(nameof(SmtpClientOptions))).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
     }
 
     /// <summary>
@@ -38,7 +38,7 @@ public static class IServiceCollectionExtensions
     /// <remarks>Adds the <see cref="IEmailProviderFactory"/> to retrieve instances of <see cref="IEmailProvider"/> in the given <paramref name="serviceLifetime">service lifetime</paramref>.</remarks>
     /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="options">Action to configure options for the email provider.</param>
-    /// <param name="serviceLifetime">The lifetime for the e-mail proider service. By default it is <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <param name="serviceLifetime">The lifetime for the e-mail provider service. By default it is <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     /// <seealso href="http://www.mimekit.net/"/>
     public static IServiceCollection AddMailKitEmailProvider(this IServiceCollection services, Action<SmtpClientOptions> options, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
@@ -55,12 +55,12 @@ public static class IServiceCollectionExtensions
     /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="configuration">The current set of key-value application configuration parameters.</param>
     /// <param name="options">Action to configure options for the email provider.</param>
-    /// <param name="serviceLifetime">The lifetime for the e-mail proider service. By default it is <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <param name="serviceLifetime">The lifetime for the e-mail provider service. By default it is <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     /// <seealso href="http://www.mimekit.net/"/>
     public static IServiceCollection AddMailKitEmailProvider(this IServiceCollection services, IConfiguration configuration, Action<SmtpClientOptions> options, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
     {
-        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration?.GetSection(nameof(SmtpClientOptions))).PostConfigure(options).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
+        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration.GetSection(nameof(SmtpClientOptions))).PostConfigure(options).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
     }
 
     private static IServiceCollection InnerAddMailKitEmailProvider(this IServiceCollection services, Action<OptionsBuilder<SmtpClientOptions>> setupOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)

--- a/src/Encamina.Enmarcha.Email.MailKit/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/Extensions/IServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ public static class IServiceCollectionExtensions
     /// <seealso href="http://www.mimekit.net/"/>
     public static IServiceCollection AddMailKitEmailProvider(this IServiceCollection services, IConfiguration configuration, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
     {
-        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration?.GetSection(nameof(SmtpClientOptions))).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
+        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration.GetSection(nameof(SmtpClientOptions))).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public static class IServiceCollectionExtensions
     /// <seealso href="http://www.mimekit.net/"/>
     public static IServiceCollection AddMailKitEmailProvider(this IServiceCollection services, IConfiguration configuration, Action<SmtpClientOptions> options, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
     {
-        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration?.GetSection(nameof(SmtpClientOptions))).PostConfigure(options).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
+        return services.InnerAddMailKitEmailProvider(optionBuilder => optionBuilder.Bind(configuration.GetSection(nameof(SmtpClientOptions))).PostConfigure(options).ValidateDataAnnotations().ValidateOnStart(), serviceLifetime);
     }
 
     private static IServiceCollection InnerAddMailKitEmailProvider(this IServiceCollection services, Action<OptionsBuilder<SmtpClientOptions>> setupOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)


### PR DESCRIPTION
- Enhanced EmailAttachmentSpecification.cs by allowing ContentType to be nullable, addressing CS8618 warning.
- Updated EmailSpecification.cs to permit Body to be nullable, resolving CS8618 warnings.
- Modified IEmailBuilder.cs to allow senderName and recipientName to be nullable, addressing CS8625 warnings. Additionally, minor refactoring has been performed.
- Updated EmailService.cs to align with the method signatures defined in IEmailBuilder.
- Added new GPT-4o info in ModelInfo.cs.