### PR TITLE
Fixed some warnings in Encamina.Enmarcha.SemanticKernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ Previous classification is not required if changes are simple or all belong to t
 ### Minor Changes
 
 - Added `MaxTokensOutput` property in `ModelInfo`.
+- Added `SaveChatMessagesHistoryBatchAsync` in `ChatHistoryProvider`.
+- Fixed some warnings in:
+    - `Encamina.Enmarcha.Bot`
+    - `Encamina.Enmarcha.Core`
+    - `Encamina.Enmarcha.Data`
+    - `Encamina.Enmarcha.Email`
+    - `Encamina.Enmarcha.Entities`
+    - `Encamina.Enmarcha.SemanticKernel` 
 
 ## [8.1.6]
 
@@ -86,14 +94,7 @@ Previous classification is not required if changes are simple or all belong to t
 - Fixed some warnings in:
   - `Encamina.Enmarcha.AI`.
   - `Encamina.Enmarcha.AspNet`
-  - `Encamina.Enmarcha.Bot`
-  - `Encamina.Enmarcha.Core`
-  - `Encamina.Enmarcha.Data`
-  - `Encamina.Enmarcha.Email`
-  - `Encamina.Enmarcha.Entities`
-  - `Encamina.Enmarcha.SemanticKernel`
 - Corrected a typo in the Spanish error message in `ResponseMessages.es.resx` from "ha encontrar" to "ha encontrado".
-- Added `SaveChatMessagesHistoryBatchAsync` in `ChatHistoryProvider`.
  
 ## [8.1.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Previous classification is not required if changes are simple or all belong to t
   - `Encamina.Enmarcha.Core`
   - `Encamina.Enmarcha.Data`
   - `Encamina.Enmarcha.Email`
+  - `Encamina.Enmarcha.Entities`
  
 ## [8.1.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Previous classification is not required if changes are simple or all belong to t
   - `Encamina.Enmarcha.Data`
   - `Encamina.Enmarcha.Email`
   - `Encamina.Enmarcha.Entities`
+  - `Encamina.Enmarcha.SemanticKernel`
  
 ## [8.1.5]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.6</VersionPrefix>
-    <VersionSuffix>preview-13</VersionSuffix>
+    <VersionSuffix>preview-14</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.7</VersionPrefix>
-    <VersionSuffix>preview-05</VersionSuffix>
+    <VersionSuffix>preview-06</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.6</VersionPrefix>
-    <VersionSuffix>preview-12</VersionSuffix>
+    <VersionSuffix>preview-13</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Entities.Abstractions/IServiceFactory{T}.cs
+++ b/src/Encamina.Enmarcha.Entities.Abstractions/IServiceFactory{T}.cs
@@ -24,7 +24,7 @@ public interface IServiceFactory<out T> : IDisposable where T : class
     /// otherwise <see langword="false"/> and don't throw any exception.
     /// </param>
     /// <returns>A valid instance of the service if found.</returns>
-    T ById<TId>(TId serviceId, bool throwIfNotFound);
+    T? ById<TId>(TId serviceId, bool throwIfNotFound);
 
     /// <summary>
     /// Gets a service by its name.
@@ -42,7 +42,7 @@ public interface IServiceFactory<out T> : IDisposable where T : class
     /// otherwise <see langword="false"/> and don't throw any exception.
     /// </param>
     /// <returns>A valid instance of the service if found.</returns>
-    T ByName(string serviceName, bool throwIfNotFound);
+    T? ByName(string serviceName, bool throwIfNotFound);
 
     /// <summary>
     /// Gets a service by its type.
@@ -64,5 +64,5 @@ public interface IServiceFactory<out T> : IDisposable where T : class
     /// otherwise <see langword="false"/> and don't throw any exception.
     /// </param>
     /// <returns>A valid instance of the service if found.</returns>
-    T ByType(Type serviceType, bool throwIfNotFound);
+    T? ByType(Type serviceType, bool throwIfNotFound);
 }

--- a/src/Encamina.Enmarcha.Entities.Abstractions/IdentifiableBase{T}.cs
+++ b/src/Encamina.Enmarcha.Entities.Abstractions/IdentifiableBase{T}.cs
@@ -13,5 +13,5 @@ public abstract class IdentifiableBase<T> : IIdentifiable<T>
     public virtual T Id { get; init; }
 
     /// <inheritdoc/>
-    object IIdentifiable.Id => Id;
+    object IIdentifiable.Id => Id!;
 }

--- a/src/Encamina.Enmarcha.Entities/ServiceFactory{T}.cs
+++ b/src/Encamina.Enmarcha.Entities/ServiceFactory{T}.cs
@@ -27,28 +27,28 @@ public class ServiceFactory<T> : IServiceFactory<T> where T : class
     }
 
     /// <inheritdoc/>
-    public virtual T ById<TId>(TId serviceId) => ById(serviceId, true);
+    public virtual T ById<TId>(TId serviceId) => ById(serviceId, true)!;
 
     /// <inheritdoc/>
-    public virtual T ById<TId>(TId serviceId, bool throwIfNotFound)
+    public virtual T? ById<TId>(TId serviceId, bool throwIfNotFound)
     {
         return ProcessService(GetService<T>(s => s is IIdentifiable<TId> identifiable && identifiable.Id.Equals(serviceId)), throwIfNotFound, Resources.ExceptionMessages.InvalidServiceId, nameof(serviceId), typeof(T), serviceId);
     }
 
     /// <inheritdoc/>
-    public virtual T ByName(string serviceName) => ByName(serviceName, true);
+    public virtual T ByName(string serviceName) => ByName(serviceName, true)!;
 
     /// <inheritdoc/>
-    public virtual T ByName(string serviceName, bool throwIfNotFound)
+    public virtual T? ByName(string serviceName, bool throwIfNotFound)
     {
         return ProcessService(GetService<T>(s => s is INameable nameable && nameable.Name.Equals(serviceName)), throwIfNotFound, Resources.ExceptionMessages.InvalidServiceName, nameof(serviceName), typeof(T), serviceName);
     }
 
     /// <inheritdoc/>
-    public virtual T ByType(Type serviceType) => ByType(serviceType, true);
+    public virtual T ByType(Type serviceType) => ByType(serviceType, true)!;
 
     /// <inheritdoc/>
-    public virtual T ByType(Type serviceType, bool throwIfNotFound)
+    public virtual T? ByType(Type serviceType, bool throwIfNotFound)
     {
         return ProcessService(GetService<T>(s => s.GetType() == serviceType), throwIfNotFound, Resources.ExceptionMessages.InvaidServiceType, nameof(serviceType), serviceType);
     }
@@ -67,7 +67,7 @@ public class ServiceFactory<T> : IServiceFactory<T> where T : class
     /// This method disposes the <see cref="IServiceScope"/> used by this factory.
     /// </remarks>
     /// <param name="disposing">
-    /// A flag value indicating whether this instance is being disponsed or not, to prevent redundant calls.
+    /// A flag value indicating whether this instance is being disposed or not, to prevent redundant calls.
     /// </param>
     protected virtual void Dispose(bool disposing)
     {
@@ -82,7 +82,7 @@ public class ServiceFactory<T> : IServiceFactory<T> where T : class
         }
     }
 
-    private static T ProcessService(T service, bool throwIfNotFound, string exceptionMessage, string parameterName, params object[] exceptionMessageParameters)
+    private static T? ProcessService(T service, bool throwIfNotFound, string exceptionMessage, string parameterName, params object[] exceptionMessageParameters)
     {
         return service == null && throwIfNotFound
             ? throw new ArgumentException(string.Format(exceptionMessage, exceptionMessageParameters), parameterName)

--- a/src/Encamina.Enmarcha.Net.Http/Extensions/HttpContextExtensions.cs
+++ b/src/Encamina.Enmarcha.Net.Http/Extensions/HttpContextExtensions.cs
@@ -22,7 +22,7 @@ public static class HttpContextExtensions
         Guard.IsNotNull(headerName);
 
         return httpContext.Request.Headers.TryGetValue(headerName, out var headerValue) && headerValue.Any()
-            ? headerValue[0].TrimAndAsNullIfEmpty() ?? defaultValue
+            ? headerValue[0]?.TrimAndAsNullIfEmpty() ?? defaultValue
             : defaultValue;
     }
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IChatHistoryProvider.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IChatHistoryProvider.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.SemanticKernel.ChatCompletion;
+﻿using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace Encamina.Enmarcha.SemanticKernel.Abstractions;
 
@@ -34,4 +35,13 @@ public interface IChatHistoryProvider
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>A <see cref="Task"/> that on completion indicates the asynchronous operation has executed.</returns>
     Task SaveChatMessagesHistoryAsync(string indexerId, string roleName, string message, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Save a set of messages in the chat history.
+    /// </summary>
+    /// <param name="indexerId">The unique identifier of the chat history indexer.</param>
+    /// <param name="messages">The list of messages to be saved.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
+    /// <returns>A <see cref="Task"/> that on completion indicates the asynchronous operation has executed.</returns>
+    Task SaveChatMessagesHistoryBatchAsync(string indexerId, IEnumerable<ChatMessageContent> messages, CancellationToken cancellationToken);
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IMemoryStoreExtender.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/IMemoryStoreExtender.cs
@@ -44,7 +44,7 @@ public interface IMemoryStoreExtender
         string collectionName,
         IEnumerable<string> chunks,
         Kernel kernel,
-        IDictionary<string, string> metadata = null,
+        IDictionary<string, string>? metadata = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -63,7 +63,7 @@ public interface IMemoryStoreExtender
     /// <param name="collectionName">Name of the collection where the content will be retrieved.</param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
     /// <returns>A <see cref="Task"/> containing the <see cref="MemoryContent"/>, or <see langword="null"/> if the content could not be found.</returns>
-    Task<MemoryContent> GetMemoryAsync(string memoryId, string collectionName, CancellationToken cancellationToken);
+    Task<MemoryContent?> GetMemoryAsync(string memoryId, string collectionName, CancellationToken cancellationToken);
 
     /// <summary>
     /// Checks if the memory exists in a collection.

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/MemoryContent.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/MemoryContent.cs
@@ -8,7 +8,7 @@ public sealed class MemoryContent
     /// <summary>
     /// Gets the metadata of the memory.
     /// </summary>
-    public IDictionary<string, string> Metadata { get; init; }
+    public IDictionary<string, string>? Metadata { get; init; }
 
     /// <summary>
     /// Gets the chunks of the memory.

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/MemoryContent.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/MemoryContent.cs
@@ -8,7 +8,7 @@ public sealed class MemoryContent
     /// <summary>
     /// Gets the metadata of the memory.
     /// </summary>
-    public IDictionary<string, string>? Metadata { get; init; }
+    public IDictionary<string, string> Metadata { get; init; }
 
     /// <summary>
     /// Gets the chunks of the memory.

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/ExcelToMarkdownDocumentConnector.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/ExcelToMarkdownDocumentConnector.cs
@@ -127,7 +127,7 @@ public class ExcelToMarkdownDocumentConnector : IDocumentConnector
         // Intentionally not implemented to comply with the Liskov Substitution Principle
     }
 
-    private static string ApplyStyles(string value, bool bold, bool italic)
+    private static string? ApplyStyles(string? value, bool bold, bool italic)
     {
         if (string.IsNullOrWhiteSpace(value))
         {
@@ -157,7 +157,7 @@ public class ExcelToMarkdownDocumentConnector : IDocumentConnector
         return value;
     }
 
-    private string GetCellTextValue(Cell cell)
+    private string? GetCellTextValue(Cell cell)
     {
         // Get the cell value with or without formatting
         var cellValue = WithFormattedValues ? cell.FormattedText : cell.Text;

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/PdfWithTocDocumentConnector.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/PdfWithTocDocumentConnector.cs
@@ -107,7 +107,7 @@ public class PdfWithTocDocumentConnector : CleanPdfDocumentConnector
                 // It is the last title. Extract the text to the end.
 
                 var lastPage = pages.MaxBy(p => p.Number);
-                var lastIndex = lastPage.Content.Length;
+                var lastIndex = lastPage!.Content.Length;
 
                 tocContent = GetTocContent(pages, currentPage, currentIndex, lastPage, lastIndex);
             }

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/DocumentConnectorProviderBase.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/DocumentConnectorProviderBase.cs
@@ -34,11 +34,11 @@ public class DocumentConnectorProviderBase : IDocumentConnectorProvider
     /// <inheritdoc/>
     public virtual IDocumentConnector GetDocumentConnector(string fileExtension)
     {
-        return GetDocumentConnector(fileExtension, true);
+        return GetDocumentConnector(fileExtension, true)!;
     }
 
     /// <inheritdoc/>
-    public IDocumentConnector GetDocumentConnector(string fileExtension, bool throwException)
+    public IDocumentConnector? GetDocumentConnector(string fileExtension, bool throwException)
     {
         if (documentConnectors.TryGetValue(fileExtension.ToUpperInvariant(), out var value))
         {

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Extensions/CellTypeExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Extensions/CellTypeExtensions.cs
@@ -77,7 +77,7 @@ internal static class CellTypeExtensions
     /// <param name="cell">The cell to get the value from.</param>
     /// <param name="workbookPart">The workbook part that contains the cell.</param>
     /// <returns>The raw text value of the cell.</returns>
-    public static string GetCellTextValue(this CellType cell, WorkbookPart workbookPart)
+    public static string? GetCellTextValue(this CellType cell, WorkbookPart workbookPart)
     {
         if (cell == null)
         {
@@ -103,7 +103,7 @@ internal static class CellTypeExtensions
     /// <param name="cell">The cell to get the value from.</param>
     /// <param name="workbookPart">The workbook part that contains the cell.</param>
     /// <returns>The formatted text value of the cell.</returns>
-    public static string GetCellFormattedTextValue(this CellType cell, WorkbookPart workbookPart)
+    public static string? GetCellFormattedTextValue(this CellType cell, WorkbookPart workbookPart)
     {
         if (cell == null)
         {
@@ -118,7 +118,7 @@ internal static class CellTypeExtensions
 
             if (cellFormat?.NumberFormatId != null)
             {
-                string format = workbookPart.WorkbookStylesPart.Stylesheet.NumberingFormats.Elements<NumberingFormat>()
+                string? format = workbookPart.WorkbookStylesPart.Stylesheet.NumberingFormats.Elements<NumberingFormat>()
                     .FirstOrDefault(i => i.NumberFormatId == cellFormat.NumberFormatId)?
                     .FormatCode;
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Extensions/CellTypeExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Extensions/CellTypeExtensions.cs
@@ -51,7 +51,7 @@ internal static class CellTypeExtensions
     /// <param name="cell">The cell to get the value from.</param>
     /// <param name="workbookPart">The workbook part that contains the cell.</param>
     /// <returns>A tuple containing the cell value and a boolean indicating whether the cell contains text.</returns>
-    public static (string Value, bool IsText) GetCellValue(this CellType cell, WorkbookPart workbookPart)
+    public static (string? Value, bool IsText) GetCellValue(this CellType cell, WorkbookPart workbookPart)
     {
         if (cell == null)
         {
@@ -114,11 +114,11 @@ internal static class CellTypeExtensions
             && double.TryParse(cell.CellValue?.InnerText, out var number)
             && cell.StyleIndex != null && workbookPart.WorkbookStylesPart?.Stylesheet is { CellFormats: not null, NumberingFormats: not null })
         {
-            var cellFormat = workbookPart.WorkbookStylesPart.Stylesheet.CellFormats.ElementAtOrDefault((int)cell.StyleIndex.Value) as CellFormat;
+            var cellFormat = workbookPart.WorkbookStylesPart.Stylesheet.CellFormats?.ElementAtOrDefault((int)cell.StyleIndex.Value) as CellFormat;
 
             if (cellFormat?.NumberFormatId != null)
             {
-                string? format = workbookPart.WorkbookStylesPart.Stylesheet.NumberingFormats.Elements<NumberingFormat>()
+                string? format = workbookPart.WorkbookStylesPart.Stylesheet.NumberingFormats?.Elements<NumberingFormat>()
                     .FirstOrDefault(i => i.NumberFormatId == cellFormat.NumberFormatId)?
                     .FormatCode;
 
@@ -127,7 +127,7 @@ internal static class CellTypeExtensions
                     format = defaultFormat;
                 }
 
-                return ConvertToExcelFormat(number, format);
+                return ConvertToExcelFormat(number, format!);
             }
         }
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/IDocumentConnectorProvider.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/IDocumentConnectorProvider.cs
@@ -29,7 +29,7 @@ public interface IDocumentConnectorProvider
     /// <exception cref="InvalidOperationException">
     /// If the <paramref name="fileExtension"/> is not supported or no suitable <see cref="IDocumentConnector"/> instance for it can be found.
     /// </exception>
-    IDocumentConnector GetDocumentConnector(string fileExtension, bool throwException);
+    IDocumentConnector? GetDocumentConnector(string fileExtension, bool throwException);
 
     /// <summary>
     /// Determines whether a specified file extension is supported.

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Models/Excel/Cell.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Models/Excel/Cell.cs
@@ -12,12 +12,12 @@ internal class Cell
     /// <summary>
     /// Gets the text in the cell.
     /// </summary>
-    public string Text { get; private init; }
+    public string? Text { get; private init; }
 
     /// <summary>
     /// Gets the formatted text in the cell.
     /// </summary>
-    public string FormattedText { get; private init; }
+    public string? FormattedText { get; private init; }
 
     /// <summary>
     /// Gets a value indicating whether the text in the cell is null, empty or white space.
@@ -27,7 +27,7 @@ internal class Cell
     /// <summary>
     /// Gets the reference of the cell. Such us A1, B2, etc.
     /// </summary>
-    public string Reference { get; private init; }
+    public string? Reference { get; private init; }
 
     /// <summary>
     /// Gets a value indicating whether the text in the cell is bold.

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Models/Excel/Worksheet.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Models/Excel/Worksheet.cs
@@ -15,7 +15,7 @@ internal class Worksheet
     /// <summary>
     /// Gets the name of the worksheet.
     /// </summary>
-    public string Name { get; private init; }
+    public string? Name { get; private init; }
 
     /// <summary>
     /// Gets a value indicating whether the worksheet is hidden.
@@ -150,7 +150,7 @@ internal class Worksheet
     {
         return worksheet.Descendants<Row>()
             .Where((r) => r.Hidden != null && r.Hidden.Value && r.RowIndex?.Value is not null)
-            .Select(r => (int)r.RowIndex.Value)
+            .Select(r => (int)r.RowIndex!.Value)
             .ToList();
     }
 
@@ -163,7 +163,7 @@ internal class Worksheet
     {
         return worksheet.Descendants<Column>()
             .Where(c => c.Hidden != null && c.Hidden.Value && c.Min != null && c.Max != null)
-            .SelectMany(c => Enumerable.Range((int)c.Min.Value, (int)c.Max.Value - (int)c.Min.Value + 1))
+            .SelectMany(c => Enumerable.Range((int)c.Min!.Value, (int)c.Max!.Value - (int)c.Min.Value + 1))
             .ToList();
     }
 
@@ -304,8 +304,8 @@ internal class Worksheet
     /// <returns>A list of rows, each containing a list of cells, representing the range of cells with text.</returns>
     private static List<List<Cell>> GetOnlyCellsRangeWithText(IList<List<Cell>> rows)
     {
-        var firstNonEmptyRowIndex = rows.IndexOf(rows.FirstOrDefault(r => r.Exists(c => !c.IsNullOrWhiteSpace)));
-        var lastNonEmptyRowIndex = rows.IndexOf(rows.LastOrDefault(r => r.Exists(c => !c.IsNullOrWhiteSpace)));
+        var firstNonEmptyRowIndex = rows.IndexOf(rows.FirstOrDefault(r => r.Exists(c => !c.IsNullOrWhiteSpace))!);
+        var lastNonEmptyRowIndex = rows.IndexOf(rows.LastOrDefault(r => r.Exists(c => !c.IsNullOrWhiteSpace))!);
 
         var columnsRange = Enumerable.Range(0, rows[0].Count).ToList();
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/ChatHistoryProvider.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/ChatHistoryProvider.cs
@@ -5,7 +5,7 @@ using Encamina.Enmarcha.SemanticKernel.Plugins.Chat.Options;
 using Encamina.Enmarcha.SemanticKernel.Plugins.Chat.Plugins;
 
 using Microsoft.Extensions.Options;
-
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace Encamina.Enmarcha.SemanticKernel.Plugins.Chat;
@@ -112,5 +112,18 @@ public class ChatHistoryProvider : IChatHistoryProvider
             Message = message,
             TimestampUtc = DateTime.UtcNow,
         }, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveChatMessagesHistoryBatchAsync(string indexerId, IEnumerable<ChatMessageContent> messages, CancellationToken cancellationToken)
+    {
+        await chatMessagesHistoryRepository.AddBatchAsync(messages.Select(message => new ChatMessageHistoryRecord()
+        {
+            Id = Guid.NewGuid().ToString(),
+            IndexerId = indexerId,
+            RoleName = message.Role.ToString(),
+            Message = message.Content!,
+            TimestampUtc = DateTime.UtcNow,
+        }), cancellationToken);
     }
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Plugins/ChatWithHistoryPlugin.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Plugins/ChatWithHistoryPlugin.cs
@@ -61,12 +61,12 @@ public class ChatWithHistoryPlugin
     [KernelFunction]
     [Description(@"Allows users to chat and ask questions to an Artificial Intelligence.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage(@"Design", @"CA1068:CancellationToken parameters must come last", Justification = @"We want to have optional parameters")]
-    public virtual async Task<string> ChatAsync(
+    public virtual async Task<string?> ChatAsync(
         CancellationToken cancellationToken,
         [Description(@"What the user says or asks when chatting")] string ask,
         [Description(@"The unique identifier of the chat history indexer")] string chatIndexerId,
-        [Description(@"The name of the user")] string userName = null,
-        [Description(@"The preferred language of the user while chatting")] string locale = null)
+        [Description(@"The name of the user")] string? userName = null,
+        [Description(@"The preferred language of the user while chatting")] string? locale = null)
     {
         var systemPrompt = SystemPrompt;
 
@@ -133,7 +133,7 @@ public class ChatWithHistoryPlugin
     /// <param name="chatModelTokens">Total tokens supported by the chat model.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>The error message.</returns>
-    protected virtual async Task<string> GetErrorMessageAsync(ChatHistory chatHistory, string locale, int systemPromptTokens, int askTokens, int chatModelTokens, CancellationToken cancellationToken)
+    protected virtual async Task<string?> GetErrorMessageAsync(ChatHistory chatHistory, string locale, int systemPromptTokens, int askTokens, int chatModelTokens, CancellationToken cancellationToken)
     {
         var prompt = @$"Please translate from 'EN-us' to '{locale}' the following text: The length of the system prompt is {systemPromptTokens} and the length of the user ask is {askTokens}. The maximum length of the prompt and the user ask is {chatModelTokens}.";
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Plugins/ChatWithHistoryPlugin.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Plugins/ChatWithHistoryPlugin.cs
@@ -4,7 +4,6 @@ using Encamina.Enmarcha.AI.OpenAI.Abstractions;
 using Encamina.Enmarcha.SemanticKernel.Abstractions;
 using Encamina.Enmarcha.SemanticKernel.Plugins.Chat.Options;
 
-using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
 
 using Microsoft.SemanticKernel;

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Plugins/ChatWithHistoryPlugin.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Plugins/ChatWithHistoryPlugin.cs
@@ -138,7 +138,7 @@ public class ChatWithHistoryPlugin
     /// <param name="chatModelTokens">Total tokens supported by the chat model.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>The error message.</returns>
-    protected virtual async Task<string?> GetErrorMessageAsync(ChatHistory chatHistory, string locale, int systemPromptTokens, int askTokens, int chatModelTokens, CancellationToken cancellationToken)
+    protected virtual async Task<string?> GetErrorMessageAsync(ChatHistory chatHistory, string? locale, int systemPromptTokens, int askTokens, int chatModelTokens, CancellationToken cancellationToken)
     {
         var prompt = @$"Please translate from 'EN-us' to '{locale}' the following text: The length of the system prompt is {systemPromptTokens} and the length of the user ask is {askTokens}. The maximum length of the prompt and the user ask is {chatModelTokens}.";
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Plugins/QuestionAnsweringPlugin.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Plugins/QuestionAnsweringPlugin.cs
@@ -87,13 +87,13 @@ public class QuestionAnsweringPlugin
     /// <returns>A string representing the answer for the <paramref name="question"/> based on all the information found from searching the memory's collections.</returns>
     [KernelFunction]
     [Description(@"Answer questions using information obtained from a memory. The given question is used as query to search from a list (usually comma-separated) of collections. The result is used as context to answer the question.")]
-    public virtual async Task<string> QuestionAnsweringFromMemoryQueryAsync(
+    public virtual async Task<string?> QuestionAnsweringFromMemoryQueryAsync(
         [Description(@"The question to answer and search the memory for")] string question,
         [Description(@"A list of memory's collections, usually comma-separated")] string collectionsStr,
         [Description(@"Minimum relevance for the search results")] double minRelevance = 0.75,
         [Description(@"Maximum number of results per queried collection")] int resultsLimit = 20,
         [Description(@"The character (usually a comma) that separates each collection from the given list of collections")] char collectionSeparator = ',',
-        [Description(@"The locale in which the response is generated. This parameter is optional. If not provided, the question language is used.")] string locale = null,
+        [Description(@"The locale in which the response is generated. This parameter is optional. If not provided, the question language is used.")] string? locale = null,
         CancellationToken cancellationToken = default)
     {
         // This method was designed to maximize the use of tokens in an LLM model (like GPT).
@@ -145,10 +145,10 @@ public class QuestionAnsweringPlugin
     /// <returns>A string representing the answer for the <paramref name="input"/> based on all the information found from searching the memory's collections.</returns>
     [KernelFunction]
     [Description(@"Answer questions using information from a context.")]
-    public virtual async Task<string> QuestionAnsweringFromContextAsync(
+    public virtual async Task<string?> QuestionAnsweringFromContextAsync(
         [Description(@"The question to answer with information from a context.")] string input,
         [Description(@"Context with information that may contain the answer for question")] string context,
-        [Description(@"The locale in which the response is generated. This parameter is optional. If not provided, the input language is used.")] string locale = null,
+        [Description(@"The locale in which the response is generated. This parameter is optional. If not provided, the input language is used.")] string? locale = null,
         CancellationToken cancellationToken = default)
     {
         var functionArguments = new KernelArguments(questionAnsweringFromContextFunctionExecutionSettings)
@@ -163,14 +163,14 @@ public class QuestionAnsweringPlugin
         return functionResult.GetValue<string>();
     }
 
-    private static string GetAnswerLocale(string locale)
+    private static string GetAnswerLocale(string? locale)
     {
         return string.IsNullOrWhiteSpace(locale)
             ? "the SAME LANGUAGE as the QUESTION"
             : $"\"{locale}\" LANGUAGE";
     }
 
-    private Task<int> GetQuestionAnsweringFromContextFunctionUsedTokensAsync(KernelFunction questionAnsweringFromContextFunction, string input, string locale, CancellationToken cancellationToken)
+    private Task<int> GetQuestionAnsweringFromContextFunctionUsedTokensAsync(KernelFunction questionAnsweringFromContextFunction, string input, string? locale, CancellationToken cancellationToken)
     {
         var functionArguments = new KernelArguments(questionAnsweringFromContextFunctionExecutionSettings)
         {

--- a/src/Encamina.Enmarcha.SemanticKernel/Extensions/KernelExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel/Extensions/KernelExtensions.cs
@@ -40,7 +40,7 @@ public static class KernelExtensions
     /// </param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>A string containing the generated prompt.</returns>
-    public static async Task<string> GetKernelFunctionPromptAsync(this Kernel kernel, string pluginDirectory, KernelFunction function, KernelArguments arguments, string promptTemplateFormat = null, IPromptTemplateFactory promptTemplateFactory = null, CancellationToken cancellationToken = default)
+    public static async Task<string> GetKernelFunctionPromptAsync(this Kernel kernel, string pluginDirectory, KernelFunction function, KernelArguments arguments, string? promptTemplateFormat = null, IPromptTemplateFactory? promptTemplateFactory = null, CancellationToken cancellationToken = default)
     {
         var promptConfigPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, pluginDirectory, function.Name, Constants.ConfigFile);
 
@@ -84,7 +84,7 @@ public static class KernelExtensions
     /// </param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>A string containing the generated prompt.</returns>
-    public static async Task<string> GetKernelFunctionPromptAsync(this Kernel kernel, string pluginName, Assembly assembly, KernelFunction function, KernelArguments arguments, string promptTemplateFormat = null, IPromptTemplateFactory promptTemplateFactory = null, CancellationToken cancellationToken = default)
+    public static async Task<string> GetKernelFunctionPromptAsync(this Kernel kernel, string pluginName, Assembly assembly, KernelFunction function, KernelArguments arguments, string? promptTemplateFormat = null, IPromptTemplateFactory? promptTemplateFactory = null, CancellationToken cancellationToken = default)
     {
         Guard.IsNotNullOrWhiteSpace(pluginName);
 
@@ -123,7 +123,7 @@ public static class KernelExtensions
     /// </param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>A string containing the generated prompt.</returns>
-    public static Task<string> GetKernelPromptAsync(this Kernel kernel, string promptTemplate, KernelArguments arguments, string promptTemplateFormat = null, IPromptTemplateFactory promptTemplateFactory = null, CancellationToken cancellationToken = default)
+    public static Task<string> GetKernelPromptAsync(this Kernel kernel, string promptTemplate, KernelArguments arguments, string? promptTemplateFormat = null, IPromptTemplateFactory? promptTemplateFactory = null, CancellationToken cancellationToken = default)
     {
         if (promptTemplateFactory is not null && string.IsNullOrWhiteSpace(promptTemplateFormat))
         {
@@ -161,7 +161,7 @@ public static class KernelExtensions
     /// </param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>The total number of tokens used plus the maximum allowed response tokens specified in the function.</returns>
-    public static async Task<int> GetKernelFunctionUsedTokensAsync(this Kernel kernel, string pluginDirectory, KernelFunction function, KernelArguments arguments, Func<string, int> tokenLengthFunction, string promptTemplateFormat = null, IPromptTemplateFactory promptTemplateFactory = null, CancellationToken cancellationToken = default)
+    public static async Task<int> GetKernelFunctionUsedTokensAsync(this Kernel kernel, string pluginDirectory, KernelFunction function, KernelArguments arguments, Func<string, int> tokenLengthFunction, string? promptTemplateFormat = null, IPromptTemplateFactory? promptTemplateFactory = null, CancellationToken cancellationToken = default)
     {
         return tokenLengthFunction(await kernel.GetKernelFunctionPromptAsync(pluginDirectory, function, arguments, promptTemplateFormat, promptTemplateFactory, cancellationToken))
             + GetMaxTokensFromKernelFunction(kernel, function, arguments);
@@ -184,7 +184,7 @@ public static class KernelExtensions
     /// </param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>The total number of tokens used plus the maximum allowed response tokens specified in the function.</returns>
-    public static async Task<int> GetKernelFunctionUsedTokensAsync(this Kernel kernel, string pluginName, Assembly assembly, KernelFunction function, KernelArguments arguments, Func<string, int> tokenLengthFunction, string promptTemplateFormat = null, IPromptTemplateFactory promptTemplateFactory = null, CancellationToken cancellationToken = default)
+    public static async Task<int> GetKernelFunctionUsedTokensAsync(this Kernel kernel, string pluginName, Assembly assembly, KernelFunction function, KernelArguments arguments, Func<string, int> tokenLengthFunction, string? promptTemplateFormat = null, IPromptTemplateFactory? promptTemplateFactory = null, CancellationToken cancellationToken = default)
     {
         return tokenLengthFunction(await kernel.GetKernelFunctionPromptAsync(pluginName, assembly, function, arguments, promptTemplateFormat, promptTemplateFactory, cancellationToken))
             + GetMaxTokensFromKernelFunction(kernel, function, arguments);
@@ -206,7 +206,7 @@ public static class KernelExtensions
     /// </param>
     /// <param name="cancellationToken">A cancellation token that can be used to receive notice of cancellation.</param>
     /// <returns>The total number of tokens used, plus the maximum allowed response tokens specified in the function.</returns>
-    public static async Task<int> GetKernelFunctionUsedTokensFromPromptAsync(this Kernel kernel, string promptTemplate, KernelFunction function, KernelArguments arguments, Func<string, int> tokenLengthFunction, string promptTemplateFormat = null, IPromptTemplateFactory promptTemplateFactory = null, CancellationToken cancellationToken = default)
+    public static async Task<int> GetKernelFunctionUsedTokensFromPromptAsync(this Kernel kernel, string promptTemplate, KernelFunction function, KernelArguments arguments, Func<string, int> tokenLengthFunction, string? promptTemplateFormat = null, IPromptTemplateFactory? promptTemplateFactory = null, CancellationToken cancellationToken = default)
     {
         return tokenLengthFunction(await kernel.GetKernelPromptAsync(promptTemplate, arguments, promptTemplateFormat, promptTemplateFactory, cancellationToken))
             + GetMaxTokensFromKernelFunction(kernel, function, arguments);
@@ -223,7 +223,7 @@ public static class KernelExtensions
     /// </param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>A list of all the semantic functions found in the assembly, indexed by function name.</returns>
-    public static IEnumerable<KernelPlugin> ImportPromptFunctionsFromAssembly(this Kernel kernel, Assembly assembly, IPromptTemplateFactory promptTemplateFactory = null, ILoggerFactory loggerFactory = null)
+    public static IEnumerable<KernelPlugin> ImportPromptFunctionsFromAssembly(this Kernel kernel, Assembly assembly, IPromptTemplateFactory? promptTemplateFactory = null, ILoggerFactory? loggerFactory = null)
     {
         var plugins = new List<KernelPlugin>();
 

--- a/src/Encamina.Enmarcha.SemanticKernel/Extensions/KernelExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel/Extensions/KernelExtensions.cs
@@ -313,7 +313,7 @@ public static class KernelExtensions
 
     private static string ReadResource(Assembly assembly, string resourceName)
     {
-        using var stream = assembly.GetManifestResourceStream(resourceName);
+        using var stream = assembly.GetManifestResourceStream(resourceName) ?? throw new InvalidOperationException($"The resource stream for '{resourceName}' is null. Ensure the resource name is correct and the resource is embedded in the assembly.");
         using var streamReader = new StreamReader(stream!);
 
         return streamReader.ReadToEnd();

--- a/src/Encamina.Enmarcha.SemanticKernel/Extensions/KernelExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel/Extensions/KernelExtensions.cs
@@ -314,7 +314,7 @@ public static class KernelExtensions
     private static string ReadResource(Assembly assembly, string resourceName)
     {
         using var stream = assembly.GetManifestResourceStream(resourceName);
-        using var streamReader = new StreamReader(stream);
+        using var streamReader = new StreamReader(stream!);
 
         return streamReader.ReadToEnd();
     }

--- a/src/Encamina.Enmarcha.SemanticKernel/MemoryStoreExtender.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel/MemoryStoreExtender.cs
@@ -44,7 +44,7 @@ public class MemoryStoreExtender : IMemoryStoreExtender
     public void RaiseMemoryStoreEvent(MemoryStoreEventArgs e) => MemoryStoreEvent?.Invoke(this, e);
 
     /// <inheritdoc/>
-    public virtual async Task UpsertMemoryAsync(string memoryId, string collectionName, IEnumerable<string> chunks, Kernel kernel, IDictionary<string, string> metadata = null, CancellationToken cancellationToken = default)
+    public virtual async Task UpsertMemoryAsync(string memoryId, string collectionName, IEnumerable<string> chunks, Kernel kernel, IDictionary<string, string>? metadata = null, CancellationToken cancellationToken = default)
     {
         await DeleteMemoryAsync(memoryId, collectionName, cancellationToken);
         await SaveChunks(memoryId, collectionName, chunks, metadata, kernel, cancellationToken);
@@ -63,7 +63,7 @@ public class MemoryStoreExtender : IMemoryStoreExtender
     }
 
     /// <inheritdoc/>
-    public virtual async Task<MemoryContent> GetMemoryAsync(string memoryId, string collectionName, CancellationToken cancellationToken)
+    public virtual async Task<MemoryContent?> GetMemoryAsync(string memoryId, string collectionName, CancellationToken cancellationToken)
     {
         var chunkSize = await GetChunkSize(memoryId, collectionName, cancellationToken);
 
@@ -153,7 +153,7 @@ public class MemoryStoreExtender : IMemoryStoreExtender
         return int.Parse(metadata[ChunkSize]);
     }
 
-    private async Task SaveChunks(string memoryId, string collectionName, IEnumerable<string> chunks, IDictionary<string, string> metadata, Kernel kernel, CancellationToken cancellationToken)
+    private async Task SaveChunks(string memoryId, string collectionName, IEnumerable<string> chunks, IDictionary<string, string>? metadata, Kernel kernel, CancellationToken cancellationToken)
     {
         metadata ??= new Dictionary<string, string>();
 

--- a/src/Encamina.Enmarcha.SemanticKernel/MemoryStoreExtender.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel/MemoryStoreExtender.cs
@@ -107,7 +107,7 @@ public class MemoryStoreExtender : IMemoryStoreExtender
 
             if (totalChunks > 0)
             {
-                memoryContent.Metadata.Add(Constants.MetadataTotalChunksCount, totalChunks.ToString());
+                memoryContent.Metadata?.Add(Constants.MetadataTotalChunksCount, totalChunks.ToString());
 
                 var embeddingTasks = memoryContent.Chunks.Select(async (chunk, i) =>
                 {
@@ -126,7 +126,8 @@ public class MemoryStoreExtender : IMemoryStoreExtender
 
         await foreach (var key in asyncKeys)
         {
-            logger.LogInformation(@"Processed memory record {item}.", key);
+            var message = @"Processed memory record {item}.";
+            logger.LogInformation(message, key);
 
             keys.Add(key);
 
@@ -150,7 +151,7 @@ public class MemoryStoreExtender : IMemoryStoreExtender
 
         var metadata = JsonSerializer.Deserialize<Dictionary<string, string>>(firstMemoryChunk.Metadata.AdditionalMetadata);
 
-        return int.Parse(metadata[ChunkSize]);
+        return int.Parse(metadata![ChunkSize]);
     }
 
     private async Task SaveChunks(string memoryId, string collectionName, IEnumerable<string> chunks, IDictionary<string, string>? metadata, Kernel kernel, CancellationToken cancellationToken)


### PR DESCRIPTION
- Added the possibility for T to be null in the ById and ByName methods in IServiceFactory{T}.cs.
- Added a guarantee that Id cannot be null in IdentifiableBase{T}.cs.
- Modified ServiceFactory{T}.cs to comply with the IServiceFactory{T} interface.
- Added the possibility for headerValue[0] to be null in HttpContextExtensions.cs within Encamina.Enmarcha.Net.
- Added a new SaveChatMessagesHistoryBatchAsync method in IChatHistoryProvider.cs.
- Modified MemoryContent methods in IMemoryStoreExtender.cs to fix some warnings.
- Modified MemoryContent.cs to comply with the interface signature.
- Added the ability for GetCellTextValue and ApplyStyles to return null in ExcelToMarkdownDocumentConnector.cs.
- Added a guarantee that lastPage cannot be null in PdfWithTocDocumentConnector.cs.
- Modified the GetDocumentConnector method to allow it to return null, except when throwException is true, in DocumentConnectorProviderBase.cs.
- Indicated that GetCellValue can be passed a null string, and that GetCellTextValue and GetCellFormattedTextValue can return null.
- Modified GetDocumentConnector to allow it to return null in IDocumentConnectorProvider.cs.
- Modified Cell.cs so that the Text, FormattedText, and Reference attributes can be null.
- Modified Worksheet.cs so that the Name attribute can return null, and indicated in several methods that some parameters cannot be null, with a guarantee.
- Implemented the SaveChatMessagesHistoryBatchAsync method in ChatHistoryProvider.cs.
- Modified some parameters of the ChatAsync method to allow them to be null, and updated the logic to use the newly implemented method in ChatWithHistoryPlugin.
- Modified the QuestionAnsweringFromContextAsync and QuestionAnsweringFromMemoryQueryAsync methods to allow them to return null strings. Additionally, modified parameters of other methods to indicate that they can be null.
- Indicated that the promptTemplateFormat parameter can be null in the GetKernelFunctionPromptAsync, GetKernelFunctionUsedTokensAsync, and GetKernelFunctionUsedTokensFromPromptAsync methods in KernelExtensions.cs. Also, ensured that the stream cannot be null in StreamReader.
- Modified the GetMemoryAsync method to allow it to return null. Additionally, indicated that the metadata attribute can be null in other methods.