### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,35 @@ Previous classification is not required if changes are simple or all belong to t
 
 ## [8.1.7]
 
+### Major Changes
+
+- Updated dependencies:
+    - Updated `Azure.AI.OpenAI` from `1.0.0-beta.16` to `1.0.0-beta.17`.
+    - Updated `Azure.Core` from `1.38.0` to `1.40.0`.
+    - Updated `Bogus` from `35.5.0` to `35.5.1`.
+    - Updated `MailKit` from `4.5.0` to `4.7.0`.
+    - Updated `Microsoft.AspNetCore.Authentication.JwtBearer` from `8.0.4` to `8.0.6`.
+    - Updated `Microsoft.AspNetCore.Authentication.OpenIdConnect` from `8.0.4` to `8.0.6`.
+    - Updated `Microsoft.Azure.Cosmos` from `3.39.0` to `3.41.0`.
+    - Updated `Microsoft.Bot.Builder.Azure` from `4.22.3` to `4.22.7`.
+    - Updated `Microsoft.Bot.Builder.Azure.Blobs` from `4.22.3` to `4.22.7`.
+    - Updated `Microsoft.Bot.Builder.Dialogs` from `4.22.3` to `4.22.7`.
+    - Updated `Microsoft.Bot.Builder.Integration.ApplicationInsights.Core` from `4.22.3` to `4.22.7`.
+    - Updated `Microsoft.Bot.Builder.Integration.AspNet.Core` from `4.22.3` to `4.22.7`.
+    - Updated `Microsoft.EntityFrameworkCore` from `8.0.4` to `8.0.6`.
+    - Updated `Microsoft.EntityFrameworkCore.SqlServer` from `8.0.4` to `8.0.6`.
+    - Updated `Microsoft.Extensions.Azure` from `1.7.3` to `1.7.4`.
+    - Updated `Microsoft.NET.Test.Sdk` from `17.9.0` to `17.10.0`.
+    - Updated `Microsoft.SemanticKernel.Abstractions` from `1.10.0` to `1.15.0`.
+    - Updated `Microsoft.SemanticKernel.Core` from `1.10.0` to `1.15.0`.
+    - Updated `MimeKit` from `4.5.0` to `4.7.0`.
+    - Updated `SharpToken` from `2.0.2` to `2.0.3`.
+    - Updated `Swashbuckle.AspNetCore.SwaggerGen` from `6.5.0` to `6.6.2`.
+    - Updated `xunit` from `2.7.1` to `2.8.1`.
+    - Updated `xunit.analyzers` from `1.12.0` to `1.14.0`.
+    - Updated `xunit.extensibility.core` from `2.7.1` to `2.8.1`.
+    - Updated `xunit.runner.visualstudio` from `2.5.8` to `2.8.1`.
+
 ### Minor Changes
 
 - Added `MaxTokensOutput` property in `ModelInfo`.
@@ -28,8 +57,8 @@ Previous classification is not required if changes are simple or all belong to t
     - `Encamina.Enmarcha.Data`
     - `Encamina.Enmarcha.Email`
     - `Encamina.Enmarcha.Entities`
-    - `Encamina.Enmarcha.SemanticKernel` 
-
+    - `Encamina.Enmarcha.SemanticKernel`
+  
 ## [8.1.6]
 
 ### Breaking Changes 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.7</VersionPrefix>
-    <VersionSuffix>preview-07</VersionSuffix>
+    <VersionSuffix>preview-08</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/samples/Data/Encamina.Enmarcha.Samples.Data.EntityFramework/Encamina.Enmarcha.Samples.Data.EntityFramework.csproj
+++ b/samples/Data/Encamina.Enmarcha.Samples.Data.EntityFramework/Encamina.Enmarcha.Samples.Data.EntityFramework.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.AI.IntentsPrediction.Azure/Encamina.Enmarcha.AI.IntentsPrediction.Azure.csproj
+++ b/src/Encamina.Enmarcha.AI.IntentsPrediction.Azure/Encamina.Enmarcha.AI.IntentsPrediction.Azure.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Azure.AI.Language.Conversations" Version="1.1.0" />
-        <PackageReference Include="Azure.Core" Version="1.38.0" />
+        <PackageReference Include="Azure.Core" Version="1.40.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />

--- a/src/Encamina.Enmarcha.AI.OpenAI.Azure/Encamina.Enmarcha.AI.OpenAI.Azure.csproj
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Azure/Encamina.Enmarcha.AI.OpenAI.Azure.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.16" />
-        <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.3" />
+        <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.17" />
+        <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.4" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />

--- a/src/Encamina.Enmarcha.AspNet.Mvc/Encamina.Enmarcha.AspNet.Mvc.csproj
+++ b/src/Encamina.Enmarcha.AspNet.Mvc/Encamina.Enmarcha.AspNet.Mvc.csproj
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.AspNet.OpenApi.Swashbuckle/Encamina.Enmarcha.AspNet.OpenApi.Swashbuckle.csproj
+++ b/src/Encamina.Enmarcha.AspNet.OpenApi.Swashbuckle/Encamina.Enmarcha.AspNet.OpenApi.Swashbuckle.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>      
       <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Encamina.Enmarcha.Bot.Abstractions.csproj
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Encamina.Enmarcha.Bot.Abstractions.csproj
@@ -10,8 +10,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.3" />
-        <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+        <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.7" />
+        <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.Bot/Encamina.Enmarcha.Bot.csproj
+++ b/src/Encamina.Enmarcha.Bot/Encamina.Enmarcha.Bot.csproj
@@ -22,11 +22,11 @@
           <TreatAsUsed>true</TreatAsUsed>
           <!-- This project needs this package reference to fix warning NU1701 -->
         </PackageReference>
-        <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.22.3" />
-        <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.22.3" />
-        <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.3" />
-        <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.22.3" />
-        <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+        <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.22.7" />
+        <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.22.7" />
+        <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.7" />
+        <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.22.7" />
+        <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
 

--- a/src/Encamina.Enmarcha.Data.Cosmos/Encamina.Enmarcha.Data.Cosmos.csproj
+++ b/src/Encamina.Enmarcha.Data.Cosmos/Encamina.Enmarcha.Data.Cosmos.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />

--- a/src/Encamina.Enmarcha.Data.EntityFramework/Encamina.Enmarcha.Data.EntityFramework.csproj
+++ b/src/Encamina.Enmarcha.Data.EntityFramework/Encamina.Enmarcha.Data.EntityFramework.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Encamina.Enmarcha.Email.MailKit/Encamina.Enmarcha.Email.MailKit.csproj
+++ b/src/Encamina.Enmarcha.Email.MailKit/Encamina.Enmarcha.Email.MailKit.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MailKit" Version="4.5.0" />
+        <PackageReference Include="MailKit" Version="4.7.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />

--- a/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Abstractions/Encamina.Enmarcha.SemanticKernel.Abstractions.csproj
@@ -17,9 +17,9 @@
     </PropertyGroup>
 
     <ItemGroup>        
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.10.0" PrivateAssets="none" />
-        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.10.0" />
-        <PackageReference Include="SharpToken" Version="2.0.2" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.15.0" PrivateAssets="none" />
+        <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.15.0" />
+        <PackageReference Include="SharpToken" Version="2.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Chat/Encamina.Enmarcha.SemanticKernel.Plugins.Chat.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.10.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.Memory/Encamina.Enmarcha.SemanticKernel.Plugins.Memory.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.10.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.15.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering/Encamina.Enmarcha.SemanticKernel.Plugins.QuestionAnswering.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.10.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Encamina.Enmarcha.Testing.Smtp/Encamina.Enmarcha.Testing.Smtp.csproj
+++ b/src/Encamina.Enmarcha.Testing.Smtp/Encamina.Enmarcha.Testing.Smtp.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="MimeKit" Version="4.5.0" />
+    <PackageReference Include="MimeKit" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Encamina.Enmarcha.Testing/Encamina.Enmarcha.Testing.csproj
+++ b/src/Encamina.Enmarcha.Testing/Encamina.Enmarcha.Testing.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Bogus" Version="35.5.0" />
+    <PackageReference Include="Bogus" Version="35.5.1" />
   </ItemGroup>
     
   <ItemGroup>

--- a/tst/Directory.Build.targets
+++ b/tst/Directory.Build.targets
@@ -12,12 +12,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>   
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />    
-    <PackageReference Include="xunit" Version="2.7.1" />
-    <PackageReference Include="xunit.analyzers" Version="1.12.0" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.7.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.analyzers" Version="1.14.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Updated `Azure.AI.OpenAI` from `1.0.0-beta.16` to `1.0.0-beta.17`.
- Updated `Azure.Core` from `1.38.0` to `1.40.0`.
- Updated `Bogus` from `35.5.0` to `35.5.1`.
- Updated `MailKit` from `4.5.0` to `4.7.0`.
- Updated `Microsoft.AspNetCore.Authentication.JwtBearer` from `8.0.4` to `8.0.6`.
- Updated `Microsoft.AspNetCore.Authentication.OpenIdConnect` from `8.0.4` to `8.0.6`.
- Updated `Microsoft.Azure.Cosmos` from `3.39.0` to `3.41.0`.
- Updated `Microsoft.Bot.Builder.Azure` from `4.22.3` to `4.22.7`.
- Updated `Microsoft.Bot.Builder.Azure.Blobs` from `4.22.3` to `4.22.7`.
- Updated `Microsoft.Bot.Builder.Dialogs` from `4.22.3` to `4.22.7`.
- Updated `Microsoft.Bot.Builder.Integration.ApplicationInsights.Core` from `4.22.3` to `4.22.7`.
- Updated `Microsoft.Bot.Builder.Integration.AspNet.Core` from `4.22.3` to `4.22.7`.
- Updated `Microsoft.EntityFrameworkCore` from `8.0.4` to `8.0.6`.
- Updated `Microsoft.EntityFrameworkCore.SqlServer` from `8.0.4` to `8.0.6`.
- Updated `Microsoft.Extensions.Azure` from `1.7.3` to `1.7.4`.
- Updated `Microsoft.NET.Test.Sdk` from `17.9.0` to `17.10.0`.
- Updated `Microsoft.SemanticKernel.Abstractions` from `1.10.0` to `1.15.0`.
- Updated `Microsoft.SemanticKernel.Core` from `1.10.0` to `1.15.0`.
- Updated `MimeKit` from `4.5.0` to `4.7.0`.
- Updated `SharpToken` from `2.0.2` to `2.0.3`.
- Updated `Swashbuckle.AspNetCore.SwaggerGen` from `6.5.0` to `6.6.2`.
- Updated `xunit` from `2.7.1` to `2.8.1`.
- Updated `xunit.analyzers` from `1.12.0` to `1.14.0`.
- Updated `xunit.extensibility.core` from `2.7.1` to `2.8.1`.
- Updated `xunit.runner.visualstudio` from `2.5.8` to `2.8.1`.

The `Azure.AI.OpenAI` package has not been updated to the latest version (currently 2.0.0-beta.2) due to compatibility issues with the Semantic Kernel. For more information, see the related issue [here](https://github.com/microsoft/semantic-kernel/issues/6631).