### PR TITLE
Refactor IIntentResponsesProvider functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ Previous classification is not required if changes are simple or all belong to t
 - Updated dependencies:
     - Updated `MimeKit` from `4.5.0` to `4.7.1` in `Encamina.Enmarcha.Testing.Smtp`.`
     - Updated `System.Text.Json` from `8.0.3` to `8.0.4`.
+- Refactored and reorganized the `IIntentResponsesProvider` functionality:
+  - Introduced new projects: `Encamina.Enmarcha.Conversation.Abstractions`, and `Encamina.Enmarcha.Conversation`.
+  - Moved `IIntentResponsesProvider` and `Response` classes to `Encamina.Enmarcha.Conversation.Abstractions`.
+  - Moved `TableStorageResponseProvider` class to `Encamina.Enmarcha.Conversation`.
+  - Updated `LocalizedResponseGreetingsProvider.cs` to use new abstractions.
 
 ## [8.1.7]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.8</VersionPrefix>
-    <VersionSuffix>preview-01</VersionSuffix>
+    <VersionSuffix>preview-02</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/Enmarcha.sln
+++ b/Enmarcha.sln
@@ -150,7 +150,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Encamina.Enmarcha.AspNet.Op
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Encamina.Enmarcha.Core.Tests", "tst\Encamina.Enmarcha.Core.Tests\Encamina.Enmarcha.Core.Tests.csproj", "{0516ADAE-C543-4B48-94EE-AC535DEFED0E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Encamina.Enmarcha.SemanticKernel.Connectors.Document.Tests", "tst\Encamina.Enmarcha.SemanticKernel.Connectors.Document.Tests\Encamina.Enmarcha.SemanticKernel.Connectors.Document.Tests.csproj", "{1E9782AE-28E8-4C09-A66B-22A903A76C7F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Encamina.Enmarcha.SemanticKernel.Connectors.Document.Tests", "tst\Encamina.Enmarcha.SemanticKernel.Connectors.Document.Tests\Encamina.Enmarcha.SemanticKernel.Connectors.Document.Tests.csproj", "{1E9782AE-28E8-4C09-A66B-22A903A76C7F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Encamina.Enmarcha.Conversation.Abstractions", "src\Encamina.Enmarcha.Conversation.Abstractions\Encamina.Enmarcha.Conversation.Abstractions.csproj", "{F15072A5-238C-4584-87D2-916EDE9A6BAB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Encamina.Enmarcha.Conversation", "src\Encamina.Enmarcha.Conversation\Encamina.Enmarcha.Conversation.csproj", "{854C7D01-FF78-4D69-9EC7-8ECBA0E0FA74}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -382,6 +386,14 @@ Global
 		{1E9782AE-28E8-4C09-A66B-22A903A76C7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E9782AE-28E8-4C09-A66B-22A903A76C7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E9782AE-28E8-4C09-A66B-22A903A76C7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F15072A5-238C-4584-87D2-916EDE9A6BAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F15072A5-238C-4584-87D2-916EDE9A6BAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F15072A5-238C-4584-87D2-916EDE9A6BAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F15072A5-238C-4584-87D2-916EDE9A6BAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{854C7D01-FF78-4D69-9EC7-8ECBA0E0FA74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{854C7D01-FF78-4D69-9EC7-8ECBA0E0FA74}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{854C7D01-FF78-4D69-9EC7-8ECBA0E0FA74}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{854C7D01-FF78-4D69-9EC7-8ECBA0E0FA74}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/QuestionAnsweringDialogServices.cs
+++ b/src/Encamina.Enmarcha.Bot.Skills.QuestionAnswering/QuestionAnsweringDialogServices.cs
@@ -2,7 +2,7 @@
 using Encamina.Enmarcha.AI.QuestionsAnswering.Abstractions;
 
 using Encamina.Enmarcha.Bot.Abstractions.QuestionAnswering;
-using Encamina.Enmarcha.Bot.Abstractions.Responses;
+using Encamina.Enmarcha.Conversation.Abstractions;
 
 using Microsoft.Bot.Builder;
 

--- a/src/Encamina.Enmarcha.Bot/Encamina.Enmarcha.Bot.csproj
+++ b/src/Encamina.Enmarcha.Bot/Encamina.Enmarcha.Bot.csproj
@@ -35,6 +35,7 @@
         <ProjectReference Include="..\Encamina.Enmarcha.AI.TextsTranslation.Abstractions\Encamina.Enmarcha.AI.TextsTranslation.Abstractions.csproj" />
         <ProjectReference Include="..\Encamina.Enmarcha.AI\Encamina.Enmarcha.AI.csproj" />
         <ProjectReference Include="..\Encamina.Enmarcha.Bot.Abstractions\Encamina.Enmarcha.Bot.Abstractions.csproj" />
+        <ProjectReference Include="..\Encamina.Enmarcha.Conversation\Encamina.Enmarcha.Conversation.csproj" />
         <ProjectReference Include="..\Encamina.Enmarcha.DependencyInjection\Encamina.Enmarcha.DependencyInjection.csproj" />
         <ProjectReference Include="..\Encamina.Enmarcha.Entities.Abstractions\Encamina.Enmarcha.Entities.Abstractions.csproj" />
     </ItemGroup>

--- a/src/Encamina.Enmarcha.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -5,13 +5,11 @@ using System.Globalization;
 using Encamina.Enmarcha.AI;
 
 using Encamina.Enmarcha.Bot.Abstractions.Greetings;
-using Encamina.Enmarcha.Bot.Abstractions.Responses;
 
 using Encamina.Enmarcha.Bot.Greetings;
 using Encamina.Enmarcha.Bot.Middlewares;
 using Encamina.Enmarcha.Bot.QuestionAnswering;
-using Encamina.Enmarcha.Bot.Responses;
-
+using Encamina.Enmarcha.Conversation.Abstractions;
 using Encamina.Enmarcha.Core.Extensions;
 
 using Microsoft.ApplicationInsights;
@@ -425,7 +423,7 @@ public static class IServiceCollectionExtensions
     public static IServiceCollection AddBotTableStorageResponsesProvider(this IServiceCollection services, string defaultLocale, string tableConnectionString, string tableName = @"Responses", string intentCounterSeparator = @"-", double cacheAbsoluteExpirationSeconds = 86400, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
     {
         return services.AddMemoryCache()
-                       .TryAddType<IIntentResponsesProvider>(serviceLifetime, sp => new TableStorageResponseProvider(tableConnectionString, tableName, defaultLocale, intentCounterSeparator, cacheAbsoluteExpirationSeconds, sp.GetService<IMemoryCache>()));
+            .AddTableStorageResponsesProvider(defaultLocale, tableConnectionString, tableName, intentCounterSeparator, cacheAbsoluteExpirationSeconds, serviceLifetime);
     }
 
     private static IServiceCollection AddBotTranscriptLoggerMiddleware(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)

--- a/src/Encamina.Enmarcha.Bot/Greetings/LocalizedResponseGreetingsProvider.cs
+++ b/src/Encamina.Enmarcha.Bot/Greetings/LocalizedResponseGreetingsProvider.cs
@@ -1,7 +1,7 @@
 ﻿using System.Globalization;
 
 using Encamina.Enmarcha.Bot.Abstractions.Greetings;
-using Encamina.Enmarcha.Bot.Abstractions.Responses;
+using Encamina.Enmarcha.Conversation.Abstractions;
 using Encamina.Enmarcha.Core.Extensions;
 
 using Microsoft.Bot.Builder;

--- a/src/Encamina.Enmarcha.Bot/README.md
+++ b/src/Encamina.Enmarcha.Bot/README.md
@@ -293,40 +293,6 @@ await provider.SendAsync(turnContext, cancellationToken);
 
 - `SendAsync`: Sends a greeting message based on responses retrieved from an `IIntentResponsesProvider`. The message is localized based on the culture info from the activity.
 
-## Responses
-
-### TableStorageResponseProvider
-
-`TableStorageResponseProvider` is a class that provides responses based on values configured and stored in an Azure Table Storage. It implements the `IIntentResponsesProvider` interface.
-
-#### Usage
-
-To use this class, you need to create an instance and provide the necessary parameters:
-
-```csharp
-string tableConnectionString = "Your Azure Table Storage connection string";
-string tableName = "Your table name";
-string defaultLocale = "en-US";
-string intentCounterSeparator = "-";
-double cacheAbsoluteExpirationSeconds = 86400;
-IMemoryCache memoryCache = new MemoryCache(new MemoryCacheOptions());
-
-var responseProvider = new TableStorageResponseProvider(tableConnectionString, tableName, defaultLocale, intentCounterSeparator, cacheAbsoluteExpirationSeconds, memoryCache);
-```
-You can then use this instance to get responses:
-
-```csharp
-var responses = await responseProvider.GetResponsesAsync("YourIntent", "en-US");
-```
-
-#### Constructor
-
-- `TableStorageResponseProvider`: Initializes a new instance of the class. It takes a table connection string, a table name, a default locale, an intent counter separator, a cache absolute expiration time in seconds, and an `IMemoryCache`.
- 
-#### IIntentResponsesProvider Methods
-
-As an implementation of the `IIntentResponsesProvider` interface, this class should implement methods such as `GetResponsesAsync`
-
 ## Logging
 
 ### ApplicationInsightsConversationScopedLoggerEventSource

--- a/src/Encamina.Enmarcha.Conversation.Abstractions/Encamina.Enmarcha.Conversation.Abstractions.csproj
+++ b/src/Encamina.Enmarcha.Conversation.Abstractions/Encamina.Enmarcha.Conversation.Abstractions.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.1</TargetFramework>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Encamina.Enmarcha.Entities.Abstractions\Encamina.Enmarcha.Entities.Abstractions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Encamina.Enmarcha.Conversation.Abstractions/IIntentResponsesProvider.cs
+++ b/src/Encamina.Enmarcha.Conversation.Abstractions/IIntentResponsesProvider.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 
-namespace Encamina.Enmarcha.Bot.Abstractions.Responses;
+namespace Encamina.Enmarcha.Conversation.Abstractions;
 
 /// <summary>
 /// Represents a bot's response provider from intents.

--- a/src/Encamina.Enmarcha.Conversation.Abstractions/Properties/IsExternalInit.cs
+++ b/src/Encamina.Enmarcha.Conversation.Abstractions/Properties/IsExternalInit.cs
@@ -1,0 +1,16 @@
+﻿#if NETSTANDARD2_1 || NETCOREAPP3_1 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Reserved to be used by the compiler for tracking metadata.
+/// This class should not be used by developers in source code.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal static class IsExternalInit
+{
+}
+
+#endif

--- a/src/Encamina.Enmarcha.Conversation.Abstractions/README.md
+++ b/src/Encamina.Enmarcha.Conversation.Abstractions/README.md
@@ -1,0 +1,19 @@
+﻿# Conversation Abstractions
+
+[![Nuget package](https://img.shields.io/nuget/v/Encamina.Enmarcha.Conversation.Abstractions)](https://www.nuget.org/packages/Encamina.Enmarcha.Conversation.Abstractions)
+
+This project mainly contains abstractions related to conversations used by other ENMARCHA NuGet packages or necessary for creating your own implementations.
+
+## Setup
+
+### Nuget package
+
+First, [install NuGet](http://docs.nuget.org/docs/start-here/installing-nuget). Then, install [Encamina.Enmarcha.Conversation.Abstractions](https://www.nuget.org/packages/Encamina.Enmarcha.Conversation.Abstractions) from the package manager console:
+
+    PM> Install-Package Encamina.Enmarcha.Conversation.Abstractions
+
+### .NET CLI:
+
+[Install .NET CLI](https://learn.microsoft.com/en-us/dotnet/core/tools/). Next, install [Encamina.Enmarcha.Conversation.Abstractions](https://www.nuget.org/packages/Encamina.Enmarcha.Conversation.Abstractions) from the .NET CLI:
+
+    dotnet add package Encamina.Enmarcha.Conversation.Abstractions

--- a/src/Encamina.Enmarcha.Conversation.Abstractions/Response.cs
+++ b/src/Encamina.Enmarcha.Conversation.Abstractions/Response.cs
@@ -1,6 +1,6 @@
 ﻿using Encamina.Enmarcha.Entities.Abstractions;
 
-namespace Encamina.Enmarcha.Bot.Abstractions.Responses;
+namespace Encamina.Enmarcha.Conversation.Abstractions;
 
 /// <summary>
 /// Represents a bot's response, usually obtained from a (static) repository like a database or table storage.

--- a/src/Encamina.Enmarcha.Conversation/Encamina.Enmarcha.Conversation.csproj
+++ b/src/Encamina.Enmarcha.Conversation/Encamina.Enmarcha.Conversation.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.1</TargetFramework>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+      <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Encamina.Enmarcha.Conversation.Abstractions\Encamina.Enmarcha.Conversation.Abstractions.csproj" />
+      <ProjectReference Include="..\Encamina.Enmarcha.DependencyInjection\Encamina.Enmarcha.DependencyInjection.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Encamina.Enmarcha.Conversation/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.Conversation/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Encamina.Enmarcha.Conversation;
+using Encamina.Enmarcha.Conversation.Abstractions;
+
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for configuring common and required services for bots.
+/// </summary>
+public static class IServiceCollectionExtensions
+{
+
+    /// <summary>
+    /// Adds a Table Storage as repository for localized responses.
+    /// </summary>
+    /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="defaultLocale">The default locale.</param>
+    /// <param name="tableConnectionString">The Table Storage connection string.</param>
+    /// <param name="tableName">The name of the table in the Table storage that contains the localized responses. Default name <c>Responses</c>.</param>
+    /// <param name="intentCounterSeparator">An intent counter separator for scenarios with multiple responses.</param>
+    /// <param name="cacheAbsoluteExpirationSeconds">
+    /// The absolute expiration time, relative to now in seconds for a cache to store values retrieved from the Table Storage, to improve performance. Default <c>86400</c> (i.e., 24 hours - 1 day).
+    /// </param>
+    /// <param name="serviceLifetime">The lifetime for the responses provider.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddTableStorageResponsesProvider(this IServiceCollection services, string defaultLocale, string tableConnectionString, string tableName = @"Responses", string intentCounterSeparator = @"-", double cacheAbsoluteExpirationSeconds = 86400, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+    {
+        return services.TryAddType<IIntentResponsesProvider>(serviceLifetime, sp => new TableStorageResponseProvider(tableConnectionString, tableName, defaultLocale, intentCounterSeparator, cacheAbsoluteExpirationSeconds, sp.GetRequiredService<IMemoryCache>()));
+    }
+}

--- a/src/Encamina.Enmarcha.Conversation/README.md
+++ b/src/Encamina.Enmarcha.Conversation/README.md
@@ -1,0 +1,55 @@
+﻿# Conversation
+
+[![Nuget package](https://img.shields.io/nuget/v/Encamina.Enmarcha.Conversation)](https://www.nuget.org/packages/Encamina.Enmarcha.Conversation)
+
+Conversation is a project that primarily contains cross-cutting utilities that can be used in conversational applications.
+
+## Setup
+
+### Nuget package
+
+First, [install NuGet](http://docs.nuget.org/docs/start-here/installing-nuget). Then, install [Encamina.Enmarcha.Conversation](https://www.nuget.org/packages/Encamina.Enmarcha.Conversation) from the package manager console:
+
+    PM> Install-Package Encamina.Enmarcha.Conversation
+
+### .NET CLI:
+
+[Install .NET CLI](https://learn.microsoft.com/en-us/dotnet/core/tools/). Next, install [Encamina.Enmarcha.Conversation](https://www.nuget.org/packages/Encamina.Enmarcha.Conversation) from the .NET CLI:
+
+    dotnet add package Encamina.Enmarcha.Conversation
+
+## How to use
+Below are some of the most important utilities.
+
+### TableStorageResponseProvider
+
+`TableStorageResponseProvider` is a class that provides responses based on values configured and stored in an Azure Table Storage. It implements the `IIntentResponsesProvider` interface.
+
+#### Usage
+
+To use this class, you need to create an instance and provide the necessary parameters:
+
+```csharp
+string tableConnectionString = "Your Azure Table Storage connection string";
+string tableName = "Your table name";
+string defaultLocale = "en-US";
+string intentCounterSeparator = "-";
+double cacheAbsoluteExpirationSeconds = 86400;
+IMemoryCache memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+var responseProvider = new TableStorageResponseProvider(tableConnectionString, tableName, defaultLocale, intentCounterSeparator, cacheAbsoluteExpirationSeconds, memoryCache);
+```
+You can then use this instance to get responses:
+
+```csharp
+var responses = await responseProvider.GetResponsesAsync("YourIntent", "en-US");
+```
+
+#### Constructor
+
+- `TableStorageResponseProvider`: Initializes a new instance of the class. It takes a table connection string, a table name, a default locale, an intent counter separator, a cache absolute expiration time in seconds, and an `IMemoryCache`.
+ 
+#### IIntentResponsesProvider Methods
+
+As an implementation of the `IIntentResponsesProvider` interface, this class should implement methods such as `GetResponsesAsync`
+


### PR DESCRIPTION
This PR refactors and decouples part of the Bot's functionality by moving it to a new project. This allows us to use that functionality independently without bringing along the Bot's dependencies.
  - Introduced new projects: `Encamina.Enmarcha.Conversation.Abstractions` and `Encamina.Enmarcha.Conversation`.
  - Moved `IIntentResponsesProvider` and `Response` classes to `Encamina.Enmarcha.Conversation.Abstractions`.
  - Moved `TableStorageResponseProvider` class to `Encamina.Enmarcha.Conversation`.
  - Updated `LocalizedResponseGreetingsProvider.cs` to use new abstractions.