### PR TITLE
`SkVisionImageDocumentConnector` fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Previous classification is not required if changes are simple or all belong to t
   - Moved `TableStorageResponseProvider` class to `Encamina.Enmarcha.Conversation`.
   - Updated `LocalizedResponseGreetingsProvider.cs` to use new abstractions.
 
+- Updated dependencies:
+    - Updated `Microsoft.SemanticKernel.Plugins.Document` from `1.10.0-alpha` to `1.15.0-alpha`.
+
 ### Minor Changes
 
 - Added `SetRecipients` method to `IEmailBuilder` interface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Previous classification is not required if changes are simple or all belong to t
 ### Minor Changes
 
 - Added `SetRecipients` method to `IEmailBuilder` interface.
+- Added `DocumentTooLargeException` class to handle exceptions when the document is too large to be processed.
 
 ## [8.1.7]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.8</VersionPrefix>
-    <VersionSuffix>preview-03</VersionSuffix>
+    <VersionSuffix>preview-04</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionImageDocumentConnector.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionImageDocumentConnector.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Diagnostics;
 
+using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Exceptions;
 using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Utils;
 
 using Microsoft.SemanticKernel;
@@ -80,6 +81,14 @@ public class SkVisionImageDocumentConnector : IEnmarchaDocumentConnector
 
         // TODO: We can improve that making an async version of IEnmarchaDocumentConnector.
         var response = chatCompletionService.GetChatMessageContentAsync(history).GetAwaiter().GetResult();
+
+        // Check if the the model has exceeded the output capacity.
+        if (response.Metadata?.TryGetValue(@"FinishReason", out var finishReason) == true &&
+            finishReason is string finishReasonString &&
+            finishReasonString.Equals(@"length", StringComparison.Ordinal))
+        {
+            throw new DocumentTooLargeException();
+        }
 
         return response?.Content ?? string.Empty;
     }

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
@@ -20,8 +20,7 @@
     
   <ItemGroup>
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.15.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.10.0-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.15.0-alpha" />
     <PackageReference Include="PdfPig" Version="0.1.8" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="System.Memory.Data" Version="8.0.0" />

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
@@ -20,6 +20,7 @@
     
   <ItemGroup>
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.15.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Document" Version="1.10.0-alpha" />
     <PackageReference Include="PdfPig" Version="0.1.8" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Exceptions/DocumentTooLargeException.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Exceptions/DocumentTooLargeException.cs
@@ -1,0 +1,47 @@
+﻿using System.Runtime.Serialization;
+
+namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Exceptions;
+
+/// <summary>
+/// The exception that is thrown when there has been an error with the document size.
+/// </summary>
+[Serializable]
+public class DocumentTooLargeException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentTooLargeException"/> class.
+    /// </summary>
+    public DocumentTooLargeException() : base(Resources.ExceptionMessages.DocumentTooLargeExceptionMessage)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentTooLargeException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes this exception.</param>
+    public DocumentTooLargeException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentTooLargeException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes this exception.</param>
+    /// <param name="innerException">
+    /// The exception that is the cause of the current exception.
+    /// If the <paramref name="innerException"/> parameter is not <see langword="null"/>, then the
+    /// current exception is raised in a catch block that handles the inner exception.
+    /// </param>
+    public DocumentTooLargeException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentTooLargeException"/> class.
+    /// </summary>
+    /// <param name="info">The object that holds the serialized object data.</param>
+    /// <param name="context">The contextual information about the source or destination.</param>
+    protected DocumentTooLargeException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Extensions/IServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ public static class IServiceCollectionExtensions
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddDefaultDocumentContentExtractor(this IServiceCollection services)
     {
-        return services.AddSingleton<IDocumentContentExtractor, DefaultDocumentContentExtractor>();
+        return services.AddScoped<IDocumentContentExtractor, DefaultDocumentContentExtractor>();
     }
 
     /// <summary>
@@ -33,13 +33,13 @@ public static class IServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds a default implementation of Semantic <see cref="IDocumentContentExtractor"/> to the specified <see cref="IServiceCollection"/> as a singleton service.
+    /// Adds a default implementation of Semantic <see cref="IDocumentContentExtractor"/> to the specified <see cref="IServiceCollection"/> as a scoped service.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddDefaultDocumentContentSemanticExtractor(this IServiceCollection services)
     {
-        return services.AddDefaultDocumentContentSemanticExtractor(ServiceLifetime.Singleton);
+        return services.AddDefaultDocumentContentSemanticExtractor(ServiceLifetime.Scoped);
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public static class IServiceCollectionExtensions
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddDefaultDocumentConnectorProvider(this IServiceCollection services)
     {
-        return services.AddSingleton<IDocumentConnectorProvider, DefaultDocumentContentExtractor>();
+        return services.AddScoped<IDocumentConnectorProvider, DefaultDocumentContentExtractor>();
     }
 
     /// <summary>
@@ -202,7 +202,7 @@ public static class IServiceCollectionExtensions
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddSkVisionImageDocumentConnector(this IServiceCollection services)
     {
-        return services.AddSingleton<IEnmarchaDocumentConnector, SkVisionImageDocumentConnector>();
+        return services.AddScoped<IEnmarchaDocumentConnector, SkVisionImageDocumentConnector>();
     }
 
     /// <summary>

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Resources/ExceptionMessages.Designer.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Resources/ExceptionMessages.Designer.cs
@@ -61,6 +61,15 @@ namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The document is too large or contains too much content..
+        /// </summary>
+        internal static string DocumentTooLargeExceptionMessage {
+            get {
+                return ResourceManager.GetString("DocumentTooLargeExceptionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to File extension &apos;{0}&apos; is not supported!.
         /// </summary>
         internal static string FileExtensionNotSupported {

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Resources/ExceptionMessages.resx
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Resources/ExceptionMessages.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="DocumentTooLargeExceptionMessage" xml:space="preserve">
+    <value>The document is too large or contains too much content.</value>
+  </data>
   <data name="FileExtensionNotSupported" xml:space="preserve">
     <value>File extension '{0}' is not supported!</value>
   </data>


### PR DESCRIPTION
- Fixed `SkVisionImageDocumentConnector` registration as Scoped.
- `SkVisionImageDocumentConnector` now throws a `DocumentTooLargeException` when the LLM has not been able to extract all the content.