### PR TITLE
Update ModelInfo and update `TextSplitterOptions` default values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Previous classification is not required if changes are simple or all belong to t
 
 - Added `SetRecipients` method to `IEmailBuilder` interface.
 - Added `DocumentTooLargeException` class to handle exceptions when the document is too large to be processed.
+- Added `gpt-4o-mini` to `ModelInfo`.
+- Increased tokens in `TextSplitterOptions` default values.
 
 ## [8.1.7]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.1.8</VersionPrefix>
-    <VersionSuffix>preview-04</VersionSuffix>
+    <VersionSuffix>preview-05</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.AI.Abstractions/TextSplitterOptions.cs
+++ b/src/Encamina.Enmarcha.AI.Abstractions/TextSplitterOptions.cs
@@ -12,14 +12,14 @@ public class TextSplitterOptions
     /// </summary>
     [Required]
     [Range(0, int.MaxValue)]
-    public int ChunkOverlap { get; init; } = 10;
+    public int ChunkOverlap { get; init; } = 50;
 
     /// <summary>
     /// Gets the number of elements (characters, tokens, etc.) in each chunk.
     /// </summary>
     [Required]
     [Range(0, int.MaxValue)]
-    public int ChunkSize { get; init; } = 100;
+    public int ChunkSize { get; init; } = 1000;
 
     /// <summary>
     /// Gets the collection of separator characters to use when splitting the text and creating chunks.

--- a/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/ModelInfo.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/ModelInfo.cs
@@ -12,19 +12,20 @@ public sealed class ModelInfo
 {
     private static readonly IDictionary<string, ModelInfo> ModelInfoById = new ReadOnlyDictionary<string, ModelInfo>(new Dictionary<string, ModelInfo>()
     {
-        // Chat GPT 3.5...
+        // GPT 3.5...
         { @"gpt-35-turbo-16k", new ModelInfo() { Id = @"gpt-35-turbo-16k", MaxTokens = 16200, MaxTokensOutput = 4096, Encoding = @"cl100k_base", IsObsolete = false } },
         { @"gpt-3.5-turbo-16k", new ModelInfo() { Id = @"gpt-3.5-turbo-16k", MaxTokens = 16200, MaxTokensOutput = 4096, Encoding = @"cl100k_base", IsObsolete = false } },
         { @"gpt-35-turbo", new ModelInfo() { Id = @"gpt-35-turbo", MaxTokens = 4096, MaxTokensOutput = 4096, Encoding = @"cl100k_base", IsObsolete = false } },
         { @"gpt-3.5-turbo", new ModelInfo() { Id = @"gpt-3.5-turbo", MaxTokens = 4096, MaxTokensOutput = 4096, Encoding = @"cl100k_base", IsObsolete = false } },
 
-        // Chat GPT 4...
-        { @"gpt-4", new ModelInfo() { Id = @"gpt-4", MaxTokens = 8192, MaxTokensOutput = 4096, Encoding = @"cl100k_base", IsObsolete = false } },
-        { @"gpt-4-32k", new ModelInfo() { Id = @"gpt-4", MaxTokens = 32768, MaxTokensOutput = 4096, Encoding = @"cl100k_base", IsObsolete = false } },
-        { @"gpt-4-turbo", new ModelInfo() { Id = @"gpt-4", MaxTokens = 128000, MaxTokensOutput = 4096, Encoding = @"cl100k_base", IsObsolete = false } },
+        // GPT 4...
+        { @"gpt-4", new ModelInfo() { Id = @"gpt-4", MaxTokens = 8192, MaxTokensOutput = 4096, Encoding = @"cl100k_base", IsObsolete = true } },
+        { @"gpt-4-32k", new ModelInfo() { Id = @"gpt-4", MaxTokens = 32768, MaxTokensOutput = 4096, Encoding = @"cl100k_base", IsObsolete = true } },
+        { @"gpt-4-turbo", new ModelInfo() { Id = @"gpt-4", MaxTokens = 128000, MaxTokensOutput = 4096, Encoding = @"cl100k_base", IsObsolete = true } },
         { @"gpt-4o", new ModelInfo() { Id = @"gpt-4o", MaxTokens = 128000, MaxTokensOutput = 4096, Encoding = @"o200k_base", IsObsolete = false } },
+        { @"gpt-4o-mini", new ModelInfo() { Id = @"gpt-4o-mini", MaxTokens = 128000, MaxTokensOutput = 16416, Encoding = @"o200k_base", IsObsolete = false } },
 
-        // Chat GPT 3...
+        // GPT 3...
         { @"text-davinci-001", new ModelInfo() { Id = @"text-davinci-001", MaxTokens = 2049, MaxTokensOutput = 2049, Encoding = @"r50k_base", IsObsolete = true } },
         { @"text-davinci-002", new ModelInfo() { Id = @"text-davinci-002", MaxTokens = 4097, MaxTokensOutput = 4096, Encoding = @"p50k_base", IsObsolete = true } },
         { @"text-davinci-003", new ModelInfo() { Id = @"text-davinci-003", MaxTokens = 4097, MaxTokensOutput = 4096, Encoding = @"p50k_base", IsObsolete = true } },


### PR DESCRIPTION
- Added `gpt-4o-mini` to `ModelInfo`.
- Increased tokens in `TextSplitterOptions` default values, since current LLM models have more context window.