### PR TITLE
Added conditional SMTP authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ Previous classification is not required if changes are simple or all belong to t
 
 ### Minor Changes
 
-- Added `AuthenticationNotRequired` property to `SmtpClientOptions.cs`, which can be set to `true` when the SMTP server does not require authentication (i.e., no username/password is needed).
- 
+- Added the `AuthenticationRequired` property to `SmtpClientOptions.cs`, which is set to `true` by default. This indicates that authentication is required to connect to the SMTP server. If set to `false`, the server does not require authentication, meaning no username or password is needed for the connection.
+
 ## [8.1.8]
 
 ### Breaking Changes 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Also, any bug fix must start with the prefix �Bug fix:� followed by the desc
 
 Previous classification is not required if changes are simple or all belong to the same category.
 
+## [8.1.9]
+
+### Minor Changes
+
+- Added `AuthenticationNotRequired` property to `SmtpClientOptions.cs`, which can be set to `true` when the SMTP server does not require authentication (i.e., no username/password is needed).
+ 
 ## [8.1.8]
 
 ### Breaking Changes 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>8.1.8</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>8.1.9</VersionPrefix>
+    <VersionSuffix>preview-01</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Email.Abstractions/Encamina.Enmarcha.Email.Abstractions.csproj
+++ b/src/Encamina.Enmarcha.Email.Abstractions/Encamina.Enmarcha.Email.Abstractions.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Encamina.Enmarcha.Core\Encamina.Enmarcha.Core.csproj" />
     <ProjectReference Include="..\Encamina.Enmarcha.Entities.Abstractions\Encamina.Enmarcha.Entities.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/Encamina.Enmarcha.Email.Abstractions/SmtpClientOptions.cs
+++ b/src/Encamina.Enmarcha.Email.Abstractions/SmtpClientOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Net.Security;
 
+using Encamina.Enmarcha.Core.DataAnnotations;
 using Encamina.Enmarcha.Entities.Abstractions;
 
 namespace Encamina.Enmarcha.Email.Abstractions;
@@ -11,6 +12,11 @@ namespace Encamina.Enmarcha.Email.Abstractions;
 public class SmtpClientOptions : INameable
 {
     private string? name = null;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether authentication is not required to connect to the SMTP service.
+    /// </summary>
+    public bool AuthenticationNotRequired { get; set; }
 
     /// <summary>
     /// Gets or sets the host name of the SMTP service.
@@ -28,9 +34,10 @@ public class SmtpClientOptions : INameable
 
     /// <summary>
     /// Gets or sets the password credential required to connect to the SMTP service.
+    /// <para>This property is only required if <see cref="AuthenticationNotRequired"/> is set to <see langword="false"/>.</para>
     /// </summary>
-    [Required(AllowEmptyStrings = false)]
-    public string Password { get; set; }
+    [RequiredIf(nameof(AuthenticationNotRequired), conditionalValue: false, allowEmpty: false)]
+    public string? Password { get; set; }
 
     /// <summary>
     /// Gets or sets the port for the SMTP service. Default value is <c>587</c>.
@@ -48,9 +55,10 @@ public class SmtpClientOptions : INameable
 
     /// <summary>
     /// Gets or sets the user credential required to connect to the SMTP service.
+    /// <para>This property is only required if <see cref="AuthenticationNotRequired"/> is set to <see langword="false"/>.</para>
     /// </summary>
-    [Required(AllowEmptyStrings = false)]
-    public string User { get; set; }
+    [RequiredIf(nameof(AuthenticationNotRequired), conditionalValue: false, allowEmpty: false)]
+    public string? User { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether SSL should be use. Default is <see langword="false"/>.

--- a/src/Encamina.Enmarcha.Email.Abstractions/SmtpClientOptions.cs
+++ b/src/Encamina.Enmarcha.Email.Abstractions/SmtpClientOptions.cs
@@ -14,9 +14,12 @@ public class SmtpClientOptions : INameable
     private string? name = null;
 
     /// <summary>
-    /// Gets or sets a value indicating whether authentication is not required to connect to the SMTP service.
+    /// Gets a value indicating whether authentication is required to connect to the SMTP service.
     /// </summary>
-    public bool AuthenticationNotRequired { get; set; }
+    /// <remarks>
+    /// The default value is <see langword="true"/>. Set this to <see langword="false"/> if the SMTP service does not require authentication.
+    /// </remarks>
+    public bool AuthenticationRequired { get; init; } = true;
 
     /// <summary>
     /// Gets or sets the host name of the SMTP service.
@@ -34,9 +37,9 @@ public class SmtpClientOptions : INameable
 
     /// <summary>
     /// Gets or sets the password credential required to connect to the SMTP service.
-    /// <para>This property is only required if <see cref="AuthenticationNotRequired"/> is set to <see langword="false"/>.</para>
+    /// <para>This property is only required if <see cref="AuthenticationRequired"/> is set to <see langword="false"/>.</para>
     /// </summary>
-    [RequiredIf(nameof(AuthenticationNotRequired), conditionalValue: false, allowEmpty: false)]
+    [RequiredIf(nameof(AuthenticationRequired), conditionalValue: true, allowEmpty: false)]
     public string? Password { get; set; }
 
     /// <summary>
@@ -55,9 +58,9 @@ public class SmtpClientOptions : INameable
 
     /// <summary>
     /// Gets or sets the user credential required to connect to the SMTP service.
-    /// <para>This property is only required if <see cref="AuthenticationNotRequired"/> is set to <see langword="false"/>.</para>
+    /// <para>This property is only required if <see cref="AuthenticationRequired"/> is set to <see langword="false"/>.</para>
     /// </summary>
-    [RequiredIf(nameof(AuthenticationNotRequired), conditionalValue: false, allowEmpty: false)]
+    [RequiredIf(nameof(AuthenticationRequired), conditionalValue: true, allowEmpty: false)]
     public string? User { get; set; }
 
     /// <summary>

--- a/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
@@ -108,7 +108,12 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
         }
 
         await smtpClient.ConnectAsync(SmtpClientOptions.Host, SmtpClientOptions.Port, SmtpClientOptions.UseSSL, cancellationToken);
-        await smtpClient.AuthenticateAsync(SmtpClientOptions.User, SmtpClientOptions.Password, cancellationToken);
+
+        if (!SmtpClientOptions.AuthenticationNotRequired)
+        {
+            await smtpClient.AuthenticateAsync(SmtpClientOptions.User, SmtpClientOptions.Password, cancellationToken);
+        }
+
         await smtpClient.SendAsync(mailMessage, cancellationToken);
         await smtpClient.DisconnectAsync(true, cancellationToken);
     }

--- a/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
+++ b/src/Encamina.Enmarcha.Email.MailKit/EmailService.cs
@@ -109,7 +109,7 @@ internal sealed class EmailService : IEmailBuilder, IEmailProvider, ISmtpClientO
 
         await smtpClient.ConnectAsync(SmtpClientOptions.Host, SmtpClientOptions.Port, SmtpClientOptions.UseSSL, cancellationToken);
 
-        if (!SmtpClientOptions.AuthenticationNotRequired)
+        if (SmtpClientOptions.AuthenticationRequired)
         {
             await smtpClient.AuthenticateAsync(SmtpClientOptions.User, SmtpClientOptions.Password, cancellationToken);
         }


### PR DESCRIPTION
Introduced conditional SMTP authentication based on a new property.
- **SmtpClientOptions.cs**: Added `AuthenticationRequired` property and conditional requirements for `Password` and `User`.
- **EmailService.cs**: Updated `SendAsync` method to use the new `AuthenticationRequired` property.
- **Changelog Update**: Added entry for version 8.1.9.
- **Version Update**: Updated version to `8.1.9-preview-01`.