### PR TITLE
New `SkVisionStrictFormatCleanPdfDocument` Connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ Previous classification is not required if changes are simple or all belong to t
 ## [8.2.1]
 
 ### Major Changes
+- Added a new sample project: `Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor`, demonstrating how to extract content from documents using Semantic Kernel connectors and vision capabilities.
+  - Interactive console example allowing content extraction from `.docx`, `.pptx`, `.txt`, `.md`, `.jpg`, `.jpeg`, `.png`, and `.pdf` files.
+- Introduced the `SkVisionImageExtractor` class, which centralizes image processing logic using vision models (via Semantic Kernel). This enhances code reuse and promotes separation of concerns.
+- Refactored `SkVisionImageDocumentConnector` to inherit from `SkVisionImageExtractor`, simplifying the implementation and removing redundant logic.
+- Added a new class: `SkVisionStrictFormatCleanPdfDocumentConnector`, which extends `StrictFormatCleanPdfDocumentConnector`:
+  - Combines strict-format PDF text extraction with image analysis and interpretation using the vision model.
+  - Detects embedded images in PDF files, processes them using vision, and appends their descriptions as additional text blocks.
+- Introduced a new virtual extension point `ProcessPageExtensions(Page page)` in `StrictFormatCleanPdfDocumentConnector`, allowing derived classes to append custom content blocks to the extracted page content.
+
 - Updated dependencies:
   - Aspire.Hosting 8.2.1 → 8.2.2
   - Azure.AI.OpenAI 2.1.0-beta.1 → 2.2.0-beta.1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.2.1</VersionPrefix>
-    <VersionSuffix>preview-01</VersionSuffix>
+    <VersionSuffix>preview-02</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/Enmarcha.sln
+++ b/Enmarcha.sln
@@ -158,6 +158,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Encamina.Enmarcha.Conversat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Encamina.Enmarcha.Aspire", "src\Encamina.Enmarcha.Aspire\Encamina.Enmarcha.Aspire.csproj", "{68632D97-CE5C-4817-9ECF-E8A47993A287}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor", "samples\SemanticKernel\Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor\Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor.csproj", "{0D324660-A1BF-4340-A55D-AD31C68F2561}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -400,6 +402,10 @@ Global
 		{68632D97-CE5C-4817-9ECF-E8A47993A287}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{68632D97-CE5C-4817-9ECF-E8A47993A287}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{68632D97-CE5C-4817-9ECF-E8A47993A287}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D324660-A1BF-4340-A55D-AD31C68F2561}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D324660-A1BF-4340-A55D-AD31C68F2561}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D324660-A1BF-4340-A55D-AD31C68F2561}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D324660-A1BF-4340-A55D-AD31C68F2561}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -419,6 +425,7 @@ Global
 		{7B6F4DC4-74E2-4013-8DBA-12B7AAAD5278} = {CBD50B5F-AFB8-4DA1-9FD7-17D98EB3ED78}
 		{0516ADAE-C543-4B48-94EE-AC535DEFED0E} = {CBD50B5F-AFB8-4DA1-9FD7-17D98EB3ED78}
 		{1E9782AE-28E8-4C09-A66B-22A903A76C7F} = {CBD50B5F-AFB8-4DA1-9FD7-17D98EB3ED78}
+		{0D324660-A1BF-4340-A55D-AD31C68F2561} = {43252034-27E2-4981-AC2D-EA986B287863}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F30DF47A-541C-4383-BCEB-E4108D06A70E}

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor.csproj
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Encamina.Enmarcha.AI.OpenAI.Azure\Encamina.Enmarcha.AI.OpenAI.Azure.csproj" />
+    <ProjectReference Include="..\..\..\src\Encamina.Enmarcha.AI\Encamina.Enmarcha.AI.csproj" />
+    <ProjectReference Include="..\..\..\src\Encamina.Enmarcha.SemanticKernel.Abstractions\Encamina.Enmarcha.SemanticKernel.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\Encamina.Enmarcha.SemanticKernel.Connectors.Document\Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj" />
+    <ProjectReference Include="..\..\..\src\Encamina.Enmarcha.SemanticKernel\Encamina.Enmarcha.SemanticKernel.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.mramos.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/Example.cs
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/Example.cs
@@ -1,0 +1,51 @@
+﻿using Encamina.Enmarcha.AI.Abstractions;
+using Encamina.Enmarcha.SemanticKernel.Connectors.Document;
+
+using Microsoft.SemanticKernel;
+
+namespace Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor;
+
+internal class Example
+{
+    private readonly Kernel kernel;
+    private readonly IDocumentConnectorProvider documentConnectorProvider;
+    private readonly IDocumentContentExtractor documentContentExtractor;
+
+    public Example(Kernel kernel, IDocumentConnectorProvider documentConnectorProvider, IDocumentContentExtractor documentContentExtractor)
+    {
+        this.kernel = kernel;
+        this.documentConnectorProvider = documentConnectorProvider;
+        this.documentContentExtractor = documentContentExtractor;
+    }
+
+    public void ExtractDocumentContent()
+    {
+        Console.WriteLine("Please enter the path to the document you want to extract content from:");
+        var filePath = Console.ReadLine();
+
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            Console.WriteLine("Invalid file path. Please try again.");
+            return;
+        }
+
+        var extension = Path.GetExtension(filePath);
+        if (!documentConnectorProvider.SupportedFileExtension(extension))
+        {
+            Console.WriteLine($"The file extension is not supported.");
+            return;
+        }
+
+        var stream = File.OpenRead(filePath);
+        var documentChunks = documentContentExtractor.GetDocumentContent(stream, extension).ToList();
+
+        // Print the extracted content
+        foreach (var chunk in documentChunks)
+        {
+            Console.WriteLine(chunk);
+            Console.WriteLine("------------");
+        }
+
+        Console.WriteLine($"Total chunks extracted: {documentChunks.Count}");
+    }
+}

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/Program.cs
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/Program.cs
@@ -1,0 +1,75 @@
+﻿using Encamina.Enmarcha.AI.Abstractions;
+using Encamina.Enmarcha.AI.OpenAI.Azure;
+using Encamina.Enmarcha.SemanticKernel.Connectors.Document;
+using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Connectors;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Microsoft.SemanticKernel;
+
+namespace Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor;
+
+internal static class Program
+{
+    private static void Main(string[] _)
+    {
+        // Create and configure builder
+        var hostBuilder = new HostBuilder()
+            .ConfigureAppConfiguration((configuration) =>
+            {
+                configuration.AddJsonFile(path: @"appsettings.json", optional: false, reloadOnChange: true)
+                             .AddJsonFile($@"appsettings.{Environment.UserName}.json", optional: true, reloadOnChange: true);
+            });
+
+        // Configure service
+        hostBuilder.ConfigureServices((hostContext, services) =>
+        {
+            services.AddScoped(_ =>
+            {
+                // Get semantic kernel options
+                var options = hostContext.Configuration.GetRequiredSection(nameof(AzureOpenAIOptions)).Get<AzureOpenAIOptions>()
+                ?? throw new InvalidOperationException(@$"Missing configuration for {nameof(AzureOpenAIOptions)}");
+
+                // Initialize semantic kernel
+                var kernel = Kernel.CreateBuilder()
+                    .AddAzureOpenAIChatCompletion(options.ChatModelDeploymentName, options.Endpoint.ToString(), options.Key)
+                    .Build();
+
+                return kernel;
+            });
+
+            services.AddRecursiveCharacterTextSplitter()
+            .AddSingleton(Enmarcha.SemanticKernel.Abstractions.ILengthFunctions.LengthByTokenCount);
+
+            services.AddDocumentConnectors(hostContext.Configuration)
+                .AddDefaultDocumentConnectorProvider()
+                .AddDefaultDocumentContentExtractor()
+                ;
+        });
+
+        var host = hostBuilder.Build();
+
+        // Initialize Examples
+        var example = new Example(host.Services.GetRequiredService<Kernel>(), 
+            host.Services.GetRequiredService<IDocumentConnectorProvider>(), 
+            host.Services.GetRequiredService<IDocumentContentExtractor>());
+
+        example.ExtractDocumentContent();
+
+        Console.WriteLine("Press any key to exit...");
+        Console.ReadKey();
+    }
+
+    public static IServiceCollection AddDocumentConnectors(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddWordDocumentConnector(); // .docx
+        services.AddParagraphPptxDocumentConnector(); // .pptx
+        services.AddTxtDocumentConnector(); // .txt; .md
+        services.AddSkVisionImageDocumentConnector(configuration); // .jpg; .jpeg; .png;
+        services.AddSingleton<IEnmarchaDocumentConnector, SkVisionStrictFormatCleanPdfDocumentConnector>(); // .pdf
+
+        return services;
+    }
+}

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/appsettings.json
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "AzureOpenAIOptions": {
+    "ChatModelName": "",                  // Name (sort of a unique identifier) of the model to use for chat.
+    "ChatModelDeploymentName": "",        // Model deployment name on the LLM (for example OpenAI) to use for chat.
+    "Endpoint": "",                       // URL for an LLM resource (like OpenAI). This should include protocol and host name.
+    "Key": ""                             // Key credential used to authenticate to an LLM resource.
+  }
+}

--- a/src/Encamina.Enmarcha.AI.Abstractions/ILengthFunctions.cs
+++ b/src/Encamina.Enmarcha.AI.Abstractions/ILengthFunctions.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Encamina.Enmarcha.AI.Abstractions;
+﻿namespace Encamina.Enmarcha.AI.Abstractions;
 
 /// <summary>
 /// <para>

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionImageDocumentConnector.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionImageDocumentConnector.cs
@@ -1,68 +1,25 @@
 ﻿using CommunityToolkit.Diagnostics;
 
-using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Exceptions;
 using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Options;
-using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Utils;
 
 using Microsoft.Extensions.Options;
-
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Connectors;
 
 /// <summary>
 /// Extracts text (OCR) and interprets information from images, diagrams and unstructured information. Uses Semantic Kernel.
 /// </summary>
-public class SkVisionImageDocumentConnector : IEnmarchaDocumentConnector
+public class SkVisionImageDocumentConnector : SkVisionImageExtractor, IEnmarchaDocumentConnector
 {
-    private const string SystemPrompt = """
-        You are an expert OCR (Optical Character Recognition) Specialist
-
-        You will receive a PDF page containing a mix of text, diagrams, images, tables, and possibly unstructured data.
-
-        Your task is to generate a complete transcription of the PDF page in Markdown format, capturing all content in detail.
-
-        Guidelines:
-
-        - Ensure complete accuracy in transcription; no information should be lost or omitted.
-        - Efficiently represent images, diagrams, and unstructured data for later processing by a Language Model.
-        - Don't generate any "![]()" links for photos.
-        - Extract the data from the graphs as a table in markdown.
-        - Approach this task methodically, thinking through each step carefully.
-        - This task is crucial for my career success; I rely on your expertise and precision.
-        - Ignore any icon image.
-        - Never add the following texts:
-            - ```markdown
-            - ```
-        - Specific Instructions for Formatting:
-
-        1. Represent diagrams or schemes using a dedicated section with discrete data in a table in Markdown format, formatted as follows:
-        [IMAGE]
-
-        2. Represent images or photos using a dedicated Markdown section with a full description of what you see, formatted as follows:
-        [PHOTO]
-
-        3. Restrain from adding any additional information or commentary. If the page is empty do not transcribe anything and just return an empty string.
-
-        4. Transcribe only in Markdown format.
-
-        Importance: The fidelity of this transcription is critical. It is essential that the content from the PDF is transcribed exactly as it appears, with no summarization or imprecise descriptions. Accuracy in representing the mixture of text, visual elements, and data is paramount for the success of my project.
-        
-        """;
-
-    private readonly IChatCompletionService chatCompletionService;
-    private readonly SkVisionImageDocumentConnectorOptions options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="SkVisionImageDocumentConnector"/> class.
     /// </summary>
     /// <param name="kernel">A valid <see cref="Kernel"/> instance.</param>
     /// <param name="options">Configuration options for this connector.</param>
     public SkVisionImageDocumentConnector(Kernel kernel, IOptions<SkVisionImageDocumentConnectorOptions> options)
+        : base(kernel, options)
     {
-        chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
-        this.options = options.Value;
     }
 
     /// <inheritdoc/>
@@ -72,37 +29,7 @@ public class SkVisionImageDocumentConnector : IEnmarchaDocumentConnector
     public virtual string ReadText(Stream stream)
     {
         Guard.IsNotNull(stream);
-
-        var (mimeType, width, height) = ImageHelper.GetImageInfo(stream);
-        stream.Position = 0;
-
-        // Check image resolution
-        if (width > options.ResolutionLimit || height > options.ResolutionLimit)
-        {
-            throw new DocumentTooLargeException();
-        }
-
-        var history = new ChatHistory(SystemPrompt);
-
-        var message = new ChatMessageContentItemCollection()
-        {
-            new ImageContent(BinaryData.FromStream(stream), mimeType),
-        };
-
-        history.AddUserMessage(message);
-
-        // TODO: We can improve that making an async version of IEnmarchaDocumentConnector.
-        var response = chatCompletionService.GetChatMessageContentAsync(history).GetAwaiter().GetResult();
-
-        // Check if the the model has exceeded the output capacity.
-        if (response.Metadata?.TryGetValue(@"FinishReason", out var finishReason) == true &&
-            finishReason is string finishReasonString &&
-            finishReasonString.Equals(@"length", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new DocumentTooLargeException();
-        }
-
-        return response?.Content ?? string.Empty;
+        return ProcessImageWithVision(stream);
     }
 
     /// <inheritdoc/>

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionImageExtractor.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionImageExtractor.cs
@@ -1,0 +1,118 @@
+﻿using CommunityToolkit.Diagnostics;
+
+using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Exceptions;
+using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Options;
+using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Utils;
+
+using Microsoft.Extensions.Options;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Connectors;
+
+/// <summary>
+/// Extracts text (OCR) and interprets information from images, diagrams and unstructured information. Uses Semantic Kernel.
+/// </summary>
+public class SkVisionImageExtractor
+{
+    /// <summary>
+    /// System prompt used for OCR and image interpretation.
+    /// </summary>
+    protected const string SystemPrompt = """
+        You are an expert OCR (Optical Character Recognition) Specialist
+
+        You will receive a PDF page containing a mix of text, diagrams, images, tables, and possibly unstructured data.
+
+        Your task is to generate a complete transcription of the PDF page in Markdown format, capturing all content in detail.
+
+        Guidelines:
+
+        - Ensure complete accuracy in transcription; no information should be lost or omitted.
+        - Efficiently represent images, diagrams, and unstructured data for later processing by a Language Model.
+        - Don't generate any "![]()" links for photos.
+        - Extract the data from the graphs as a table in markdown.
+        - Approach this task methodically, thinking through each step carefully.
+        - This task is crucial for my career success; I rely on your expertise and precision.
+        - Ignore any icon image.
+        - Never add the following texts:
+            - ```markdown
+            - ```
+        - Specific Instructions for Formatting:
+
+        1. Represent diagrams or schemes using a dedicated section with discrete data in a table in Markdown format, formatted as follows:
+        [IMAGE]
+
+        2. Represent images or photos using a dedicated Markdown section with a full description of what you see, formatted as follows:
+        [PHOTO]
+
+        3. Restrain from adding any additional information or commentary. If the page is empty do not transcribe anything and just return an empty string.
+
+        4. Transcribe only in Markdown format.
+
+        Importance: The fidelity of this transcription is critical. It is essential that the content from the PDF is transcribed exactly as it appears, with no summarization or imprecise descriptions. Accuracy in representing the mixture of text, visual elements, and data is paramount for the success of my project.
+        
+        """;
+
+    /// <summary>
+    /// The chat completion service instance.
+    /// </summary>
+    private readonly IChatCompletionService chatCompletionService;
+
+    /// <summary>
+    /// Configuration options for vision image processing.
+    /// </summary>
+    private readonly SkVisionImageDocumentConnectorOptions options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkVisionImageExtractor"/> class.
+    /// </summary>
+    /// <param name="kernel">A valid <see cref="Kernel"/> instance.</param>
+    /// <param name="options">Configuration options for vision processing.</param>
+    public SkVisionImageExtractor(Kernel kernel, IOptions<SkVisionImageDocumentConnectorOptions> options)
+    {
+        chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
+        this.options = options.Value;
+    }
+
+    /// <summary>
+    /// Processes an image stream through the vision model to extract text and interpret visual content.
+    /// </summary>
+    /// <param name="stream">The image stream to process.</param>
+    /// <returns>The extracted text description from the image.</returns>
+    /// <exception cref="DocumentTooLargeException">Thrown when the image exceeds resolution limits or output capacity.</exception>
+    public string ProcessImageWithVision(Stream stream)
+    {
+        Guard.IsNotNull(stream);
+
+        var (mimeType, width, height) = ImageHelper.GetImageInfo(stream);
+        stream.Position = 0;
+
+        // Check image resolution
+        if (width > options.ResolutionLimit || height > options.ResolutionLimit)
+        {
+            throw new DocumentTooLargeException();
+        }
+
+        var history = new ChatHistory(SystemPrompt);
+
+        var message = new ChatMessageContentItemCollection()
+        {
+            new ImageContent(BinaryData.FromStream(stream), mimeType),
+        };
+
+        history.AddUserMessage(message);
+
+        // TODO: We can improve that making an async version of IEnmarchaDocumentConnector.
+        var response = chatCompletionService.GetChatMessageContentAsync(history).GetAwaiter().GetResult();
+
+        // Check if the model has exceeded the output capacity.
+        if (response.Metadata?.TryGetValue(@"FinishReason", out var finishReason) == true &&
+            finishReason is string finishReasonString &&
+            finishReasonString.Equals(@"length", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new DocumentTooLargeException();
+        }
+
+        return response?.Content ?? string.Empty;
+    }
+}

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionStrictFormatCleanPdfDocumentConnector.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionStrictFormatCleanPdfDocumentConnector.cs
@@ -79,7 +79,7 @@ public class SkVisionStrictFormatCleanPdfDocumentConnector : StrictFormatCleanPd
     {
         var fontDetails = new FontDetails(string.Empty, false, FontDetails.DefaultWeight, false);
 
-        var lines = text.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+        var lines = text.Split('\r', '\n', StringSplitOptions.RemoveEmptyEntries);
         if (lines.Length == 0)
         {
             lines = [text];

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionStrictFormatCleanPdfDocumentConnector.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionStrictFormatCleanPdfDocumentConnector.cs
@@ -1,0 +1,101 @@
+﻿using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Options;
+
+using Microsoft.Extensions.Options;
+using Microsoft.SemanticKernel;
+
+using SixLabors.ImageSharp;
+
+using UglyToad.PdfPig.Content;
+using UglyToad.PdfPig.Core;
+using UglyToad.PdfPig.DocumentLayoutAnalysis;
+using UglyToad.PdfPig.Graphics.Colors;
+using UglyToad.PdfPig.PdfFonts;
+
+using Page = UglyToad.PdfPig.Content.Page;
+
+namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Connectors;
+
+/// <summary>
+/// A PDF document connector that combines strict formatting text extraction with vision capabilities
+/// to analyze and describe images found in the PDF document.
+/// </summary>
+public class SkVisionStrictFormatCleanPdfDocumentConnector : StrictFormatCleanPdfDocumentConnector
+{
+    private readonly SkVisionImageExtractor visionProcessor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkVisionStrictFormatCleanPdfDocumentConnector"/> class.
+    /// </summary>
+    /// <param name="kernel">A valid <see cref="Kernel"/> instance.</param>
+    /// <param name="options">Configuration options for vision processing.</param>
+    public SkVisionStrictFormatCleanPdfDocumentConnector(
+        Kernel kernel,
+        IOptions<SkVisionImageDocumentConnectorOptions> options)
+    {
+        visionProcessor = new SkVisionImageExtractor(kernel, options);
+    }
+
+    /// <inheritdoc/>
+    protected override IEnumerable<TextBlock> ProcessPageExtensions(Page page)
+    {
+        var imageTextBlocks = new List<TextBlock>();
+
+        var images = page.GetImages();
+        if (!images.Any())
+        {
+            return imageTextBlocks;
+        }
+
+        var imageIndex = 1;
+        foreach (var image in images)
+        {
+            try
+            {
+                using var imageStream = new MemoryStream(image.RawBytes.ToArray());
+                var imageDescription = visionProcessor.ProcessImageWithVision(imageStream);
+
+                if (!string.IsNullOrEmpty(imageDescription))
+                {
+                    // Create a TextBlock for the image description
+                    var imageTextBlock = CreateTextBlockFromText(
+                        $"[Image {imageIndex}] {imageDescription}",
+                        image.Bounds);
+
+                    imageTextBlocks.Add(imageTextBlock);
+                }
+            }
+            catch (UnknownImageFormatException)
+            {
+                // Skip image processing if the image format is unknown
+            }
+
+            imageIndex++;
+        }
+
+        return imageTextBlocks;
+    }
+
+    private static TextBlock CreateTextBlockFromText(string text, PdfRectangle bounds)
+    {
+        var fontDetails = new FontDetails(string.Empty, false, FontDetails.DefaultWeight, false);
+
+        var lines = text.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length == 0)
+        {
+            lines = [text];
+        }
+
+        var textLines = lines.Select(line =>
+        {
+            var startPoint = new PdfPoint(bounds.BottomLeft.X, bounds.BottomLeft.Y);
+            var endPoint = new PdfPoint(bounds.BottomRight.X, bounds.BottomRight.Y);
+            var letter = new Letter(
+                line, bounds, startPoint, endPoint, bounds.Width,
+                12, fontDetails, TextRenderingMode.Fill, GrayColor.Black, GrayColor.Black, 12, 0);
+
+            return new TextLine([new Word([letter])]);
+        }).ToList();
+
+        return new TextBlock(textLines);
+    }
+}

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/StrictFormatCleanPdfDocumentConnector.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/StrictFormatCleanPdfDocumentConnector.cs
@@ -24,19 +24,16 @@ public class StrictFormatCleanPdfDocumentConnector : CleanPdfDocumentConnector
     /// <inheritdoc/>
     public override string ReadText(Stream stream)
     {
-        if (stream == null)
-        {
-            throw new ArgumentNullException(nameof(stream));
-        }
+        ArgumentNullException.ThrowIfNull(stream);
 
         using var document = PdfDocument.Open(stream);
 
         var textBlocks = new List<TextBlock>();
         foreach (var page in document.GetPages())
         {
-            var pageTextBlocks = GetTextBlocks(page);
+            textBlocks.AddRange(GetTextBlocks(page));
 
-            textBlocks.AddRange(pageTextBlocks);
+            textBlocks.AddRange(ProcessPageExtensions(page));
         }
 
         var cleanedTextBlocks = CleanTextBlocks(document, textBlocks);
@@ -88,5 +85,16 @@ public class StrictFormatCleanPdfDocumentConnector : CleanPdfDocumentConnector
             .Select(textBlock => new TextBlockElement(textBlock));
 
         return RemoveCommonTextElements(document, horizontalTextBlocks);
+    }
+
+    /// <summary>
+    /// Extension point to process a page and append additional text blocks to the extracted content.
+    /// This method can be overridden in derived classes to provide custom processing for specific pages.
+    /// </summary>
+    /// <param name="page">The PDF page to process.</param>
+    /// <returns>Additional <see cref="TextBlock"/> to append to the page content.</returns>
+    protected virtual IEnumerable<TextBlock> ProcessPageExtensions(Page page)
+    {
+        return [];
     }
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Exceptions/DocumentTooLargeException.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Exceptions/DocumentTooLargeException.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.Serialization;
-
-namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Exceptions;
+﻿namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Exceptions;
 
 /// <summary>
 /// The exception that is thrown when there has been an error with the document size.
@@ -33,15 +31,6 @@ public class DocumentTooLargeException : Exception
     /// current exception is raised in a catch block that handles the inner exception.
     /// </param>
     public DocumentTooLargeException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DocumentTooLargeException"/> class.
-    /// </summary>
-    /// <param name="info">The object that holds the serialized object data.</param>
-    /// <param name="context">The contextual information about the source or destination.</param>
-    protected DocumentTooLargeException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/SkVisionImageExtractor.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/SkVisionImageExtractor.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 
-namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Connectors;
+namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document;
 
 /// <summary>
 /// Extracts text (OCR) and interprets information from images, diagrams and unstructured information. Uses Semantic Kernel.


### PR DESCRIPTION
- Added a new class: `SkVisionStrictFormatCleanPdfDocumentConnector`, which extends `StrictFormatCleanPdfDocumentConnector`:
  - Combines strict-format PDF text extraction with image analysis and interpretation using the vision model.
  - Detects embedded images in PDF files, processes them using vision, and appends their descriptions as additional text blocks.
- Introduced a new virtual extension point `ProcessPageExtensions(Page page)` in `StrictFormatCleanPdfDocumentConnector`, allowing derived classes to append custom content blocks to the extracted page content.
- Added a new sample project: `Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor`, demonstrating how to extract content from documents using Semantic Kernel connectors and vision capabilities.
  - Interactive console example allowing content extraction from `.docx`, `.pptx`, `.txt`, `.md`, `.jpg`, `.jpeg`, `.png`, and `.pdf` files.
- Introduced the `SkVisionImageExtractor` class, which centralizes image processing logic using vision models (via Semantic Kernel). This enhances code reuse and promotes separation of concerns.
- Refactored `SkVisionImageDocumentConnector` to inherit from `SkVisionImageExtractor`, simplifying the implementation and removing redundant logic.

