### PR TITLE
Update SkVisionImageExtractor to extract pdf images with interop = false for SkVisionStrictFormatCleanPdfDocumentConnector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ Previous classification is not required if changes are simple or all belong to t
   - xunit.extensibility.core 2.8.1 → 2.9.3
   - xunit.runner.visualstudio 2.8.1 → 3.0.2
 
+### Minor Changes
+- Updated the `BinaryData.FromStream` method in `SKVisionImageExtractor.cs` to a more robust custom implementation called `CreateImageBinaryData` implemented in `ImageHelper.cs`.
+- Added two new methods to the `ImageHelper.cs` class:
+    - Added the `CreateImageBinaryData` method that allows you to transform a Stream into BinaryData, taking into account that the image bytes may be compressed.
+    - Added `TryDecompressZlib` method that attempts to decompress compressed bytes from images.
+
 ## [8.2.0]
 
 ### Breaking Changes

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.2.1</VersionPrefix>
-    <VersionSuffix>preview-02</VersionSuffix>
+    <VersionSuffix>preview-03</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/SkVisionImageExtractor.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/SkVisionImageExtractor.cs
@@ -85,7 +85,6 @@ public class SkVisionImageExtractor
         Guard.IsNotNull(stream);
 
         var (mimeType, width, height) = ImageHelper.GetImageInfo(stream);
-        stream.Position = 0;
 
         // Check image resolution
         if (width > options.ResolutionLimit || height > options.ResolutionLimit)
@@ -97,7 +96,7 @@ public class SkVisionImageExtractor
 
         var message = new ChatMessageContentItemCollection()
         {
-            new ImageContent(BinaryData.FromStream(stream), mimeType),
+            new ImageContent(ImageHelper.CreateImageBinaryData(stream), mimeType),
         };
 
         history.AddUserMessage(message);


### PR DESCRIPTION
- Updated the `BinaryData.FromStream` method in `SKVisionImageExtractor.cs` to a more robust custom implementation called `CreateImageBinaryData` implemented in `ImageHelper.cs`.
- Added two new methods to the `ImageHelper.cs` class:
    - Added the `CreateImageBinaryData` method that allows you to transform a Stream into BinaryData, taking into account that the image bytes may be compressed.
    - Added `TryDecompressZlib` method that attempts to decompress compressed bytes from images.