### PR TITLE
Add Azure TokenCredential support to Table Storage providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Previous classification is not required if changes are simple or all belong to t
 ## [8.2.1]
 
 ### Major Changes
+- Added Azure authentication support via TokenCredential in `LocalizedHeroCardGreetingsOptionsFromTableStorage` and `TableStorageResponseProvider`.
 - Added a new sample project: `Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor`, demonstrating how to extract content from documents using Semantic Kernel connectors and vision capabilities.
   - Interactive console example allowing content extraction from `.docx`, `.pptx`, `.txt`, `.md`, `.jpg`, `.jpeg`, `.png`, and `.pdf` files.
 - Introduced the `SkVisionImageExtractor` class, which centralizes image processing logic using vision models (via Semantic Kernel). This enhances code reuse and promotes separation of concerns.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.2.1</VersionPrefix>
-    <VersionSuffix>preview-04</VersionSuffix>
+    <VersionSuffix>preview-05</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Bot.Abstractions/Greetings/ILocalizedHeroCardGreetingsOptions.cs
+++ b/src/Encamina.Enmarcha.Bot.Abstractions/Greetings/ILocalizedHeroCardGreetingsOptions.cs
@@ -17,7 +17,7 @@ public interface ILocalizedHeroCardGreetingsOptions
     public CultureInfo DefaultLocale { get; }
 
     /// <summary>
-    /// Gets a dictionary of localizard options for <see cref="HeroCard">hero cards</see>.
+    /// Gets a dictionary of localized options for <see cref="HeroCard">hero cards</see>.
     /// The <see cref="IDictionary{TKey, TValue}.Keys"/> are locale or language codes.
     /// </summary>
     public IDictionary<CultureInfo, IEnumerable<IHeroCardOptions>> LocalizedOptions { get; }

--- a/src/Encamina.Enmarcha.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@
 
 using System.Globalization;
 
+using Azure.Core;
+
 using Encamina.Enmarcha.AI;
 
 using Encamina.Enmarcha.Bot.Abstractions.Greetings;
@@ -395,6 +397,46 @@ public static class IServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Adds a localized greetings provider based on <see cref="HeroCard">hero cards</see> configured from localized parameters stored in a Table Storage.
+    /// </summary>
+    /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="defaultLocale">The default locale.</param>
+    /// <param name="tableEndpoint">The Table Storage endpoint URI.</param>
+    /// <param name="tokenCredential">The <see cref="TokenCredential"/> to use for authenticating with the Table Storage.</param>
+    /// <param name="tableName">The name of the table in the Table storage that contains the localized parameters for the greetings message. Default name <c>Greetings</c>.</param>
+    /// <param name="cacheAbsoluteExpirationSeconds">
+    /// The absolute expiration time, relative to now in seconds for a cache to store values retrieved from the Table Storage, to improve performance. Default <c>86400</c> (i.e., 24 hours - 1 day).
+    /// </param>
+    /// <param name="serviceLifetime">The lifetime for the greetings provider.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddBotLocalizedHeroCardGreetingsProvider(this IServiceCollection services, string defaultLocale, Uri tableEndpoint, TokenCredential tokenCredential, string tableName = @"Greetings", double cacheAbsoluteExpirationSeconds = 86400, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+    {
+        return services.AddMemoryCache()
+            .TryAddType<IGreetingsProvider, LocalizedHeroCardGreetingsProvider>(serviceLifetime)
+            .TryAddType<ILocalizedHeroCardGreetingsOptions>(serviceLifetime, sp => new LocalizedHeroCardGreetingsOptionsFromTableStorage(tableEndpoint, tokenCredential, tableName, defaultLocale, cacheAbsoluteExpirationSeconds, sp.GetService<IMemoryCache>()));
+    }
+
+    /// <summary>
+    /// Adds a localized greetings provider based on <see cref="HeroCard">hero cards</see> configured from localized parameters stored in a Table Storage.
+    /// </summary>
+    /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="defaultLocale">The default locale.</param>
+    /// <param name="tableEndpoint">The Table Storage endpoint URI.</param>
+    /// <param name="tokenCredentialProvider">The function to provide a <see cref="TokenCredential"/> for authenticating with the Table Storage.</param>
+    /// <param name="tableName">The name of the table in the Table storage that contains the localized parameters for the greetings message. Default name <c>Greetings</c>.</param>
+    /// <param name="cacheAbsoluteExpirationSeconds">
+    /// The absolute expiration time, relative to now in seconds for a cache to store values retrieved from the Table Storage, to improve performance. Default <c>86400</c> (i.e., 24 hours - 1 day).
+    /// </param>
+    /// <param name="serviceLifetime">The lifetime for the greetings provider.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddBotLocalizedHeroCardGreetingsProvider(this IServiceCollection services, string defaultLocale, Uri tableEndpoint, Func<IServiceProvider, TokenCredential> tokenCredentialProvider, string tableName = @"Greetings", double cacheAbsoluteExpirationSeconds = 86400, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+    {
+        return services.AddMemoryCache()
+            .TryAddType<IGreetingsProvider, LocalizedHeroCardGreetingsProvider>(serviceLifetime)
+            .TryAddType<ILocalizedHeroCardGreetingsOptions>(serviceLifetime, sp => new LocalizedHeroCardGreetingsOptionsFromTableStorage(tableEndpoint, tokenCredentialProvider(sp), tableName, defaultLocale, cacheAbsoluteExpirationSeconds, sp.GetService<IMemoryCache>()));
+    }
+
+    /// <summary>
     /// Adds a localized greetings provider based on texts responses.
     /// </summary>
     /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
@@ -424,6 +466,46 @@ public static class IServiceCollectionExtensions
     {
         return services.AddMemoryCache()
             .AddTableStorageResponsesProvider(defaultLocale, tableConnectionString, tableName, intentCounterSeparator, cacheAbsoluteExpirationSeconds, serviceLifetime);
+    }
+
+    /// <summary>
+    /// Adds a Table Storage as repository for the bot's localized responses.
+    /// </summary>
+    /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="defaultLocale">The default locale.</param>
+    /// <param name="tableEndpoint">The Table Storage endpoint URI.</param>
+    /// <param name="tokenCredential">The <see cref="TokenCredential"/> to use for authenticating with the Table Storage.</param>
+    /// <param name="tableName">The name of the table in the Table storage that contains the localized responses. Default name <c>Responses</c>.</param>
+    /// <param name="intentCounterSeparator">An intent counter separator for scenarios with multiple responses.</param>
+    /// <param name="cacheAbsoluteExpirationSeconds">
+    /// The absolute expiration time, relative to now in seconds for a cache to store values retrieved from the Table Storage, to improve performance. Default <c>86400</c> (i.e., 24 hours - 1 day).
+    /// </param>
+    /// <param name="serviceLifetime">The lifetime for the responses provider.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddBotTableStorageResponsesProvider(this IServiceCollection services, string defaultLocale, Uri tableEndpoint, TokenCredential tokenCredential, string tableName = @"Responses", string intentCounterSeparator = @"-", double cacheAbsoluteExpirationSeconds = 86400, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+    {
+        return services.AddMemoryCache()
+            .AddTableStorageResponsesProvider(defaultLocale, tableEndpoint, tokenCredential, tableName, intentCounterSeparator, cacheAbsoluteExpirationSeconds, serviceLifetime);
+    }
+
+    /// <summary>
+    /// Adds a Table Storage as repository for the bot's localized responses.
+    /// </summary>
+    /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="defaultLocale">The default locale.</param>
+    /// <param name="tableEndpoint">The Table Storage endpoint URI.</param>
+    /// <param name="tokenCredentialProvider">The function to provide a <see cref="TokenCredential"/> for authenticating with the Table Storage.</param>
+    /// <param name="tableName">The name of the table in the Table storage that contains the localized responses. Default name <c>Responses</c>.</param>
+    /// <param name="intentCounterSeparator">An intent counter separator for scenarios with multiple responses.</param>
+    /// <param name="cacheAbsoluteExpirationSeconds">
+    /// The absolute expiration time, relative to now in seconds for a cache to store values retrieved from the Table Storage, to improve performance. Default <c>86400</c> (i.e., 24 hours - 1 day).
+    /// </param>
+    /// <param name="serviceLifetime">The lifetime for the responses provider.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddBotTableStorageResponsesProvider(this IServiceCollection services, string defaultLocale, Uri tableEndpoint, Func<IServiceProvider, TokenCredential> tokenCredentialProvider, string tableName = @"Responses", string intentCounterSeparator = @"-", double cacheAbsoluteExpirationSeconds = 86400, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+    {
+        return services.AddMemoryCache()
+            .AddTableStorageResponsesProvider(defaultLocale, tableEndpoint, tokenCredentialProvider, tableName, intentCounterSeparator, cacheAbsoluteExpirationSeconds, serviceLifetime);
     }
 
     private static IServiceCollection AddBotTranscriptLoggerMiddleware(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)

--- a/src/Encamina.Enmarcha.Bot/Greetings/LocalizedHeroCardGreetingsProvider.cs
+++ b/src/Encamina.Enmarcha.Bot/Greetings/LocalizedHeroCardGreetingsProvider.cs
@@ -36,7 +36,7 @@ internal class LocalizedHeroCardGreetingsProvider : GreetingsProviderBase
     protected ILocalizedHeroCardGreetingsOptions Options { get; }
 
     /// <inheritdoc/>
-    public async override Task SendAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+    public override async Task SendAsync(ITurnContext turnContext, CancellationToken cancellationToken)
     {
         var activityLocal = turnContext.Activity.GetCultureInfoFromActivity();
 
@@ -59,7 +59,7 @@ internal class LocalizedHeroCardGreetingsProvider : GreetingsProviderBase
 
         if (Options.LocalizedOptions.TryGetValue(key, out var options))
         {
-            turnContext.Activity.Locale = key.Name;  // Set activity locale to the used for the greetings, specially if using the dafault locale.
+            turnContext.Activity.Locale = key.Name;  // Set activity locale to the used for the greetings, specially if using the default locale.
 
             foreach (var option in options)
             {

--- a/src/Encamina.Enmarcha.Conversation/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Encamina.Enmarcha.Conversation/Extensions/IServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Encamina.Enmarcha.Conversation;
+﻿using Azure.Core;
+
+using Encamina.Enmarcha.Conversation;
 using Encamina.Enmarcha.Conversation.Abstractions;
 
 using Microsoft.Extensions.Caching.Memory;
@@ -10,7 +12,6 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// </summary>
 public static class IServiceCollectionExtensions
 {
-
     /// <summary>
     /// Adds a Table Storage as repository for localized responses.
     /// </summary>
@@ -27,5 +28,50 @@ public static class IServiceCollectionExtensions
     public static IServiceCollection AddTableStorageResponsesProvider(this IServiceCollection services, string defaultLocale, string tableConnectionString, string tableName = @"Responses", string intentCounterSeparator = @"-", double cacheAbsoluteExpirationSeconds = 86400, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
     {
         return services.TryAddType<IIntentResponsesProvider>(serviceLifetime, sp => new TableStorageResponseProvider(tableConnectionString, tableName, defaultLocale, intentCounterSeparator, cacheAbsoluteExpirationSeconds, sp.GetRequiredService<IMemoryCache>()));
+    }
+
+    /// <summary>
+    /// Adds a Table Storage as repository for localized responses.
+    /// </summary>
+    /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="defaultLocale">The default locale.</param>
+    /// <param name="tableEndpoint">The Table Storage endpoint URI.</param>
+    /// <param name="tokenCredential">The <see cref="TokenCredential"/> to use for authenticating with the Table Storage.</param>
+    /// <param name="tableName">The name of the table in the Table storage that contains the localized responses. Default name <c>Responses</c>.</param>
+    /// <param name="intentCounterSeparator">An intent counter separator for scenarios with multiple responses.</param>
+    /// <param name="cacheAbsoluteExpirationSeconds">
+    /// The absolute expiration time, relative to now in seconds for a cache to store values retrieved from the Table Storage, to improve performance. Default <c>86400</c> (i.e., 24 hours - 1 day).
+    /// </param>
+    /// <param name="serviceLifetime">The lifetime for the responses provider.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddTableStorageResponsesProvider(this IServiceCollection services, string defaultLocale, Uri tableEndpoint, TokenCredential tokenCredential, string tableName = @"Responses", string intentCounterSeparator = @"-", double cacheAbsoluteExpirationSeconds = 86400, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+    {
+        return services.TryAddType<IIntentResponsesProvider>(serviceLifetime, sp => new TableStorageResponseProvider(
+            tableEndpoint,
+            tokenCredential,
+            tableName,
+            defaultLocale,
+            intentCounterSeparator,
+            cacheAbsoluteExpirationSeconds,
+            sp.GetRequiredService<IMemoryCache>()));
+    }
+
+    /// <summary>
+    /// Adds a Table Storage as repository for localized responses.
+    /// </summary>
+    /// <param name="services"> The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="defaultLocale">The default locale.</param>
+    /// <param name="tableEndpoint">The Table Storage endpoint URI.</param>
+    /// <param name="tokenCredentialProvider">The function to provide a <see cref="TokenCredential"/> for authenticating with the Table Storage.</param>
+    /// <param name="tableName">The name of the table in the Table storage that contains the localized responses. Default name <c>Responses</c>.</param>
+    /// <param name="intentCounterSeparator">An intent counter separator for scenarios with multiple responses.</param>
+    /// <param name="cacheAbsoluteExpirationSeconds">
+    /// The absolute expiration time, relative to now in seconds for a cache to store values retrieved from the Table Storage, to improve performance. Default <c>86400</c> (i.e., 24 hours - 1 day).
+    /// </param>
+    /// <param name="serviceLifetime">The lifetime for the responses provider.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddTableStorageResponsesProvider(this IServiceCollection services, string defaultLocale, Uri tableEndpoint, Func<IServiceProvider, TokenCredential> tokenCredentialProvider, string tableName = @"Responses", string intentCounterSeparator = @"-", double cacheAbsoluteExpirationSeconds = 86400, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+    {
+        return services.TryAddType<IIntentResponsesProvider>(serviceLifetime, sp => new TableStorageResponseProvider(tableEndpoint, tokenCredentialProvider(sp), tableName, defaultLocale, intentCounterSeparator, cacheAbsoluteExpirationSeconds, sp.GetRequiredService<IMemoryCache>()));
     }
 }


### PR DESCRIPTION
This pull request introduces Azure authentication support via `TokenCredential` for accessing to Azure Table Storage.
- `LocalizedHeroCardGreetingsOptionsFromTableStorage.cs`: Added support for `TokenCredential` and `Uri` for Table Storage endpoint.
- `TableStorageResponseProvider.cs`: Added support for `TokenCredential` and `Uri` for Table Storage endpoint.
- `IServiceCollectionExtensions.cs`: Introduced new method overloads to support Azure Table Storage authentication.