### PR TITLE
Added extract descriptions from scanned images in a PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,10 +75,17 @@ Previous classification is not required if changes are simple or all belong to t
   - xunit.runner.visualstudio 2.8.1 → 3.0.2
 
 ### Minor Changes
-- Updated the `BinaryData.FromStream` method in `SKVisionImageExtractor.cs` to a more robust custom implementation called `CreateImageBinaryData` implemented in `ImageHelper.cs`.
-- Added two new methods to the `ImageHelper.cs` class:
-    - Added the `CreateImageBinaryData` method that allows you to transform a Stream into BinaryData, taking into account that the image bytes may be compressed.
+- Updated the `BinaryData.FromStream` method in `SKVisionImageExtractor.cs` to a more robust custom implementation `ProcessImageAndGetBinary` implemented in `ImageHelper.cs`.
+- Added new methods for the `ImageHelper.cs` class for extract images in PDF's:
     - Added `TryDecompressZlib` method that attempts to decompress compressed bytes from images.
+    - Added `ProcessImageAndGetBinary` for processing an image and returning its binary data.
+    - Added `EnsureImageSharpCompatible` for ensuring the image is compatible with ImageSharp.
+    - Added `DetectImageInfo` for detecting image information.
+    - Added `ConvertPbmP4ToPng` for converting PBM or P4 images to PNG format.
+    - Added `ConvertCcittTiffToPng` for converting CCITT TIFF images to PNG format.
+    - Added `WrapRawCcittAsTiff` for wrapping raw CCITT data as a TIFF image.
+    - Added `ProcessImageStream` for processing an image stream.
+- Added new class `ImageInfo` to encapsulate image types information.
 
 ## [8.2.0]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.2.1</VersionPrefix>
-    <VersionSuffix>preview-05</VersionSuffix>
+    <VersionSuffix>preview-06</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/ModelInfo.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Abstractions/ModelInfo.cs
@@ -78,7 +78,7 @@ public sealed class ModelInfo
     public int MaxTokensOutput { get; init; }
 
     /// <summary>
-    /// Gets the supported encoding for the model. 
+    /// Gets the supported encoding for the model.
     /// </summary>
     public string Encoding { get; init; }
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionStrictFormatCleanPdfDocumentConnector.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionStrictFormatCleanPdfDocumentConnector.cs
@@ -52,7 +52,7 @@ public class SkVisionStrictFormatCleanPdfDocumentConnector : StrictFormatCleanPd
             try
             {
                 using var imageStream = new MemoryStream(image.RawBytes.ToArray());
-                var imageDescription = visionProcessor.ProcessImageWithVision(imageStream);
+                var imageDescription = visionProcessor.ProcessImageWithVision(imageStream, image.WidthInSamples, image.HeightInSamples);
 
                 if (!string.IsNullOrEmpty(imageDescription))
                 {

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
     
   <ItemGroup>
+    <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.660" />
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/ImageInfo.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/ImageInfo.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document;
+
+/// <summary>
+/// Provides information about an image type.
+/// </summary>
+public sealed class ImageInfo
+{
+    private static readonly IDictionary<string, ImageInfo> ImageInfoById = new ReadOnlyDictionary<string, ImageInfo>(new Dictionary<string, ImageInfo>()
+    {
+        { @"pbm-p4", new ImageInfo { Type = @"pbm-p4", MimeType = "image/x-portable-bitmap", Header = [(byte)'P', (byte)'4'], Match = header => header.Length >= 2 && header[0] == (byte)'P' && header[1] == (byte)'4' } },
+        { @"tiff-le", new ImageInfo { Type = @"tiff", MimeType = "image/tiff", Header = [0x49, 0x49, 0x2A, 0x00], Match = header => header.Length >= 4 && header[0] == 0x49 && header[1] == 0x49 && header[2] == 0x2A && header[3] == 0x00 } },
+        { @"tiff-be", new ImageInfo { Type = @"tiff", MimeType = "image/tiff", Header = [0x4D, 0x4D, 0x00, 0x2A], Match = header => header.Length >= 4 && header[0] == 0x4D && header[1] == 0x4D && header[2] == 0x00 && header[3] == 0x2A } },
+        { @"png", new ImageInfo { Type = @"png", MimeType = "image/png", Header = [0x89, 0x50, 0x4E, 0x47], Match = header => header.Length >= 4 && header[0] == 0x89 && header[1] == 0x50 && header[2] == 0x4E && header[3] == 0x47 } },
+        { @"jpeg", new ImageInfo { Type = @"jpeg", MimeType = "image/jpeg", Header = [0xFF, 0xD8], Match = header => header.Length >= 2 && header[0] == 0xFF && header[1] == 0xD8 } },
+        { @"raw-ccitt", new ImageInfo { Type = @"raw-ccitt", MimeType = "image/tiff", Header = Array.Empty<byte>(), Match = _ => false } },
+    });
+
+    /// <summary>
+    /// Gets the type of the image.
+    /// </summary>
+    public string Type { get; init; }
+
+    /// <summary>
+    /// Gets the MIME type of the image.
+    /// </summary>
+    public string MimeType { get; init; }
+
+    /// <summary>
+    /// Gets the header data associated with the current object.
+    /// </summary>
+    public byte[] Header { get; init; }
+
+    /// <summary>
+    /// Gets a function that matches the header of an image to determine if it is of the specified type.
+    /// </summary>
+    public Func<byte[], bool> Match { get; init; }
+
+    /// <summary>
+    /// Gets the image information by its type, like for example '<c>png</c>' or '<c>pbm-p4</c>'.
+    /// </summary>
+    /// <param name="type"> The image's type. For example <c>png</c> or <c>pbm-p4</c>.</param>
+    /// <returns>An images information from the given type, or <see langword="null"/> if it is not found.</returns>
+    public static ImageInfo? GetByType(string type) => ImageInfoById.TryGetValue(type, out var imageInfo) ? imageInfo : null;
+
+    /// <summary>
+    /// Gets all registered image types.
+    /// </summary>
+    /// <returns>A collection of all registered image information objects.</returns>
+    public static IEnumerable<ImageInfo> GetAll() => ImageInfoById.Values;
+}

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/SkVisionImageExtractor.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/SkVisionImageExtractor.cs
@@ -78,6 +78,8 @@ public class SkVisionImageExtractor
     /// Processes an image stream through the vision model to extract text and interpret visual content.
     /// </summary>
     /// <param name="stream">The image stream to process.</param>
+    /// <param name="rawCcittWidth"> Optional width for raw CCITT images.</param>
+    /// <param name="rawCcittHeight"> Optional height for raw CCITT images.</param>
     /// <returns>The extracted text description from the image.</returns>
     /// <exception cref="DocumentTooLargeException">Thrown when the image exceeds resolution limits or output capacity.</exception>
     public string ProcessImageWithVision(Stream stream, int? rawCcittWidth = null, int? rawCcittHeight = null)

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Utils/ImageHelper.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Utils/ImageHelper.cs
@@ -1,8 +1,12 @@
 ﻿using System.IO.Compression;
 
+using BitMiracle.LibTiff.Classic;
+
 using CommunityToolkit.Diagnostics;
 
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Utils;
 
@@ -15,85 +19,45 @@ public static class ImageHelper
     /// Gets both the MIME type and resolution (width and height) of an image from a stream.
     /// </summary>
     /// <param name="stream">The stream containing the image.</param>
+    /// <param name="rawCcittWidth">Optional width for raw CCITT images.</param>
+    /// <param name="rawCcittHeight">Optional height for raw CCITT images.</param>
     /// <returns>A tuple containing the MIME type, width, and height of the image.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when the stream is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when the stream does not contain a valid image.</exception>
-    public static (string MimeType, int Width, int Height) GetImageInfo(Stream stream)
+    public static (string MimeType, int Width, int Height) GetImageInfo(Stream stream, int? rawCcittWidth = null, int? rawCcittHeight = null)
     {
         Guard.IsNotNull(stream);
 
-        // Check if the stream is zlib compressed (common in PDF images)
-        var processedStream = TryDecompressZlib(stream) ?? stream;
-
-        try
-        {
-            using var image = Image.Load(processedStream);
-
-            var mimeType = image.Metadata.DecodedImageFormat?.DefaultMimeType ?? System.Net.Mime.MediaTypeNames.Application.Octet;
-
-            return (mimeType, image.Width, image.Height);
-        }
-        finally
-        {
-            // Dispose the decompressed stream if we created one
-            if (processedStream != stream)
-            {
-                processedStream?.Dispose();
-            }
-
-            // Reset original stream position if possible
-            if (stream.CanSeek)
-            {
-                stream.Position = 0;
-            }
-        }
+        return ProcessImageStream(stream, (image, mimeType) => (mimeType, image.Width, image.Height), rawCcittWidth, rawCcittHeight);
     }
 
     /// <summary>
-    /// Creates BinaryData from an image stream, handling potential compression or stream positioning issues.
+    /// Processes an image stream and returns its MIME type, width, height, and PNG data as a BinaryData object.
     /// </summary>
-    /// <param name="stream">The image stream.</param>
-    /// <returns>BinaryData containing the processed image data.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when the stream is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when the stream cannot be processed.</exception>
-    public static BinaryData CreateImageBinaryData(Stream stream)
+    /// <param name="stream">The stream containing the image.</param>
+    /// <param name="rawCcittWidth">Optional width for raw CCITT images.</param>
+    /// <param name="rawCcittHeight">Optional height for raw CCITT images.</param>
+    /// <returns>A tuple containing the MIME type, width, height, and PNG data as a BinaryData object.</returns>
+    public static (string MimeType, int Width, int Height, BinaryData PngData) ProcessImageAndGetBinary(Stream stream, int? rawCcittWidth = null, int? rawCcittHeight = null)
     {
         Guard.IsNotNull(stream);
 
-        try
+        if (stream.CanSeek)
         {
-            // Check if the stream is zlib compressed (common in PDF images)
-            var processedStream = TryDecompressZlib(stream) ?? stream;
+            stream.Position = 0;
+        }
 
-            try
-            {
-                if (processedStream != stream)
-                {
-                    // We have a decompressed version, use it
-                    using (processedStream)
-                    {
-                        return BinaryData.FromStream(processedStream);
-                    }
-                }
-                else
-                {
-                    // Use original stream
-                    return BinaryData.FromStream(stream);
-                }
-            }
-            finally
-            {
-                // Reset original stream position if possible
-                if (stream.CanSeek)
-                {
-                    stream.Position = 0;
-                }
-            }
-        }
-        catch (Exception ex)
+        return ProcessImageStream(stream, (image, mimeType) =>
         {
-            throw new ArgumentException("Failed to create image data from stream.", nameof(stream), ex);
-        }
+            var width = image.Width;
+            var height = image.Height;
+
+            using var ms = new MemoryStream();
+            image.Save(ms, new PngEncoder());
+            ms.Position = 0;
+
+            var pngData = BinaryData.FromStream(ms);
+
+            return (mimeType, width, height, pngData);
+        }, rawCcittWidth, rawCcittHeight);
     }
 
     /// <summary>
@@ -130,7 +94,6 @@ public static class ImageHelper
             stream.Position = 0;
         }
 
-        // Check if it starts with zlib header
         var buffer = new byte[2];
         var bytesRead = stream.Read(buffer, 0, 2);
 
@@ -144,8 +107,8 @@ public static class ImageHelper
             return null;
         }
 
-        // zlib magic numbers: 0x78 followed by 0x9C, 0xDA, or 0x01
-        if (buffer[0] != 0x78 || (buffer[1] != 0x9C && buffer[1] != 0xDA && buffer[1] != 0x01))
+        // Standard zlib header check
+        if (buffer[0] != 0x78 || buffer[1] != 0x9C && buffer[1] != 0xDA && buffer[1] != 0x01)
         {
             if (stream.CanSeek)
             {
@@ -157,15 +120,13 @@ public static class ImageHelper
 
         try
         {
-            // Reset to beginning for decompression
             if (stream.CanSeek)
             {
                 stream.Position = 0;
             }
 
-            // Skip the first 2 bytes (zlib header) and decompress with DeflateStream
-            stream.ReadByte(); // Skip 0x78
-            stream.ReadByte(); // Skip 0x9C (or other)
+            stream.ReadByte();
+            stream.ReadByte();
 
             using var deflateStream = new DeflateStream(stream, CompressionMode.Decompress, leaveOpen: true);
             var decompressedData = new MemoryStream();
@@ -176,13 +137,241 @@ public static class ImageHelper
         }
         catch
         {
-            // If decompression fails, reset stream and return null
             if (stream.CanSeek)
             {
                 stream.Position = 0;
             }
 
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Detects the image type using ImageInfo registrations, or returns "raw-ccitt" if unknown.
+    /// </summary>
+    /// <param name="stream">The stream containing the image data.</param>
+    /// <returns>An <see cref="ImageInfo"/> representing the detected image type.</returns>
+    private static ImageInfo DetectImageInfo(Stream stream)
+    {
+        stream.Position = 0;
+        var header = new byte[4];
+        var bytesRead = stream.Read(header, 0, 4);
+        stream.Position = 0;
+
+        foreach (var info in ImageInfo.GetAll())
+        {
+            if (info.Match(header))
+            {
+                return info;
+            }
+        }
+
+        // If not found, fallback to raw-ccitt
+        return ImageInfo.GetByType("raw-ccitt")!;
+    }
+
+    /// <summary>
+    /// Ensures the stream is compatible with ImageSharp. Converts PBM/CCITT/TIFF/RAW-CCITT to PNG, leaves others as is.
+    /// </summary>
+    /// <param name="stream">The image stream to process.</param>
+    /// <param name="rawCcittWidth">Optional width for raw CCITT images.</param>
+    /// <param name="rawCcittHeight">Optional height for raw CCITT images.</param>
+    /// <returns>A stream containing the image in PNG format or the original stream if already compatible.</returns>
+    private static Stream EnsureImageSharpCompatible(Stream stream, int? rawCcittWidth = null, int? rawCcittHeight = null)
+    {
+        var imageInfo = DetectImageInfo(stream);
+
+        switch (imageInfo.Type)
+        {
+            case "pbm-p4":
+                return ConvertPbmP4ToPng(stream);
+            case "tiff":
+                return ConvertCcittTiffToPng(stream);
+            case "raw-ccitt":
+                {
+                    if (rawCcittWidth is not null && rawCcittHeight is not null)
+                    {
+                        using var tiffStream = WrapRawCcittAsTiff(stream, rawCcittWidth.Value, rawCcittHeight.Value);
+                        return ConvertCcittTiffToPng(tiffStream);
+                    }
+                    else
+                    {
+                        throw new ArgumentException("Width and height must be provided for raw-ccitt images.");
+                    }
+                }
+
+            default:
+                stream.Position = 0;
+                return stream; // PNG, JPEG, etc.
+        }
+    }
+
+    /// <summary>
+    /// Converts a PBM P4 stream to a PNG stream.
+    /// </summary>
+    /// <param name="pbmStream"> The PBM P4 stream to convert.</param>
+    /// <returns>A stream containing the image in PNG format.</returns>
+    private static Stream ConvertPbmP4ToPng(Stream pbmStream)
+    {
+        pbmStream.Position = 0;
+
+        using var reader = new StreamReader(pbmStream, System.Text.Encoding.ASCII, false, 1024, leaveOpen: true);
+        var magic = reader.ReadLine();
+        if (magic != "P4")
+        {
+            throw new ArgumentException("Not a binary PBM P4");
+        }
+
+        string? line = null;
+        do
+        {
+            line = reader.ReadLine();
+        }
+        while (line.StartsWith('#'));
+
+        var dims = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var width = int.Parse(dims[0]);
+        var height = int.Parse(dims[1]);
+        var dataOffset = pbmStream.Position;
+        pbmStream.Position = dataOffset;
+        var bytesPerRow = (width + 7) / 8;
+        var bitmap = new byte[bytesPerRow * height];
+        pbmStream.Read(bitmap, 0, bitmap.Length);
+
+        using var img = new Image<L8>(width, height);
+        for (var y = 0; y < height; y++)
+        {
+            var rowOffset = y * bytesPerRow;
+            for (var x = 0; x < width; x++)
+            {
+                var bitIndex = x % 8;
+                var byteIndex = rowOffset + (x / 8);
+                var isBlack = (bitmap[byteIndex] >> (7 - bitIndex) & 0x1) == 0;
+                img[x, y] = isBlack ? new L8(0) : new L8(255);
+            }
+        }
+
+        var pngStream = new MemoryStream();
+        img.Save(pngStream, new PngEncoder());
+        pngStream.Position = 0;
+
+        return pngStream;
+    }
+
+    /// <summary>
+    /// Converts a CCITT TIFF stream to a PNG stream.
+    /// </summary>
+    /// <param name="tiffInput"> The CCITT TIFF stream to convert.</param>
+    /// <returns>A stream containing the image in PNG format.</returns>
+    private static Stream ConvertCcittTiffToPng(Stream tiffInput)
+    {
+        tiffInput.Position = 0;
+
+        using var tiff = Tiff.ClientOpen("in-memory", "r", tiffInput, new TiffStream()) ?? throw new ArgumentException("Not a valid TIFF or could not be opened.");
+        var width = tiff.GetField(TiffTag.IMAGEWIDTH)[0].ToInt();
+        var height = tiff.GetField(TiffTag.IMAGELENGTH)[0].ToInt();
+
+        var img = new Image<L8>(width, height);
+        var buffer = new byte[tiff.ScanlineSize()];
+        for (var y = 0; y < height; y++)
+        {
+            tiff.ReadScanline(buffer, y);
+            for (var x = 0; x < width; x++)
+            {
+                var byteIndex = x / 8;
+                var bitIndex = 7 - x % 8;
+                var isBlack = (buffer[byteIndex] >> bitIndex & 0x1) == 0;
+                img[x, y] = isBlack ? new L8(0) : new L8(255);
+            }
+        }
+
+        var pngStream = new MemoryStream();
+        img.Save(pngStream, new PngEncoder());
+        pngStream.Position = 0;
+
+        return pngStream; // The caller must close this stream when done
+    }
+
+    /// <summary>
+    /// Wraps a raw CCITT stream as a TIFF stream.
+    /// </summary>
+    /// <param name="rawCcittStream">The raw CCITT stream to wrap.</param>
+    /// <param name="width">The width of the image.</param>
+    /// <param name="height">The height of the image.</param>
+    /// <returns>A MemoryStream containing the TIFF representation of the raw CCITT data.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the TIFF cannot be created or written to.</exception>
+    private static MemoryStream WrapRawCcittAsTiff(Stream rawCcittStream, int width, int height)
+    {
+        rawCcittStream.Position = 0;
+        var rawData = new byte[rawCcittStream.Length];
+        rawCcittStream.Read(rawData, 0, rawData.Length);
+
+        var tiffStream = new MemoryStream();
+        var tiff = Tiff.ClientOpen("in-memory", "w", tiffStream, new TiffStream()) ?? throw new InvalidOperationException("Could not create in-memory TIFF");
+        tiff.SetField(TiffTag.IMAGEWIDTH, width);
+        tiff.SetField(TiffTag.IMAGELENGTH, height);
+        tiff.SetField(TiffTag.COMPRESSION, Compression.CCITTFAX4);
+        tiff.SetField(TiffTag.PHOTOMETRIC, Photometric.MINISWHITE);
+        tiff.SetField(TiffTag.BITSPERSAMPLE, 1);
+        tiff.SetField(TiffTag.SAMPLESPERPIXEL, 1);
+        tiff.SetField(TiffTag.ROWSPERSTRIP, height);
+        tiff.SetField(TiffTag.FILLORDER, FillOrder.MSB2LSB);
+
+        var strip = 0;
+        if (tiff.WriteRawStrip(strip, rawData, rawData.Length) == -1)
+        {
+            throw new InvalidOperationException("Could not write raw CCITT strip data");
+        }
+
+        tiff.WriteDirectory();
+
+        tiffStream.Position = 0;
+
+        return tiffStream;
+    }
+
+    /// <summary>
+    /// Handles image stream processing, ensuring resource cleanup and compatible format conversion.
+    /// </summary>
+    /// <typeparam name="T">Return type for the action performed on the image and its MIME type.</typeparam>
+    /// <param name="stream">The original image stream.</param>
+    /// <param name="action">A function that receives the loaded Image and its MIME type, and returns a value of type T.</param>
+    /// <param name="rawCcittWidth">Optional width for raw CCITT images.</param>
+    /// <param name="rawCcittHeight">Optional height for raw CCITT images.</param>
+    /// <returns>The result of the action.</returns>
+    private static T ProcessImageStream<T>(Stream stream, Func<Image, string, T> action, int? rawCcittWidth = null, int? rawCcittHeight = null)
+    {
+        // Check if the stream is zlib compressed (common in PDF images)
+        var processedStream = TryDecompressZlib(stream) ?? stream;
+
+        // Ensure the stream is compatible with ImageSharp
+        var compatibleStream = EnsureImageSharpCompatible(processedStream, rawCcittWidth, rawCcittHeight);
+
+        try
+        {
+            compatibleStream.Position = 0;
+            using var image = Image.Load(compatibleStream);
+            var info = DetectImageInfo(stream);
+            var mimeType = info.MimeType ?? image.Metadata.DecodedImageFormat?.DefaultMimeType ?? System.Net.Mime.MediaTypeNames.Application.Octet;
+
+            return action(image, mimeType);
+        }
+        finally
+        {
+            if (processedStream != stream)
+            {
+                processedStream?.Dispose();
+            }
+
+            if (compatibleStream != processedStream)
+            {
+                compatibleStream?.Dispose();
+            }
+
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
         }
     }
 }


### PR DESCRIPTION
- Various methods have been implemented in `ImageHelper` to extract scanned images from a PDF.
- An `ImageInfo` class has been added to encapsulate image types.
- The `ProcessImageWithVision` method has been modified to implement the new changes.