### PR TITLE
Added a new connector `SkVisionWordDocumentConnector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Previous classification is not required if changes are simple or all belong to t
   - Combines strict-format PDF text extraction with image analysis and interpretation using the vision model.
   - Detects embedded images in PDF files, processes them using vision, and appends their descriptions as additional text blocks.
 - Introduced a new virtual extension point `ProcessPageExtensions(Page page)` in `StrictFormatCleanPdfDocumentConnector`, allowing derived classes to append custom content blocks to the extracted page content.
+- Added a new connector `SkVisionWordDocumentConnector` to extract text, tables, hyperlinks and images from Word documents (.docx) using Semantic Kernel vision capabilities in image extractions. This capacity to extract the description for each image is realized using the existing `SkVisionImageExtractor`. This functionality is compatible with the previous `WordDocumentConector` implementation, so it can be used interchangeably using the `WordDocumentConnector:UseImageExtractor` setting.
 
 - Updated dependencies:
   - Aspire.Hosting 8.2.1 → 8.2.2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.2.1</VersionPrefix>
-    <VersionSuffix>preview-05</VersionSuffix>
+    <VersionSuffix>preview-06</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/Program.cs
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/Program.cs
@@ -15,6 +15,8 @@ internal static class Program
 {
     private static void Main(string[] _)
     {
+        Console.Clear();
+
         // Create and configure builder
         var hostBuilder = new HostBuilder()
             .ConfigureAppConfiguration((configuration) =>
@@ -64,7 +66,7 @@ internal static class Program
 
     public static IServiceCollection AddDocumentConnectors(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddWordDocumentConnector(); // .docx
+        services.AddWordDocumentConnector(configuration); // .docx
         services.AddParagraphPptxDocumentConnector(); // .pptx
         services.AddTxtDocumentConnector(); // .txt; .md
         services.AddSkVisionImageDocumentConnector(configuration); // .jpg; .jpeg; .png;

--- a/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/appsettings.json
+++ b/samples/SemanticKernel/Encamina.Enmarcha.Samples.SemanticKernel.DocumentContentExtractor/appsettings.json
@@ -1,8 +1,14 @@
 {
   "AzureOpenAIOptions": {
-    "ChatModelName": "",                  // Name (sort of a unique identifier) of the model to use for chat.
-    "ChatModelDeploymentName": "",        // Model deployment name on the LLM (for example OpenAI) to use for chat.
-    "Endpoint": "",                       // URL for an LLM resource (like OpenAI). This should include protocol and host name.
-    "Key": ""                             // Key credential used to authenticate to an LLM resource.
+    "ChatModelName": "", // Name (sort of a unique identifier) of the model to use for chat.
+    "ChatModelDeploymentName": "", // Model deployment name on the LLM (for example OpenAI) to use for chat.
+    "Endpoint": "", // URL for an LLM resource (like OpenAI). This should include protocol and host name.
+    "Key": "" // Key credential used to authenticate to an LLM resource.
+  },
+  "WordDocumentConnector": {
+    "UseImageExtractor": true // Indicates whether to use the image extractor for Word documents.
+  },
+  "SkVisionImageExtractorOptions": {
+    "ResolutionLimit": 8192 // Maximum resolution limit for images in the document.
   }
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionWordDocumentConnector.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/SkVisionWordDocumentConnector.cs
@@ -1,0 +1,50 @@
+﻿using CommunityToolkit.Diagnostics;
+
+using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Options;
+using Encamina.Enmarcha.SemanticKernel.Connectors.Document.Utils;
+
+using Microsoft.Extensions.Options;
+using Microsoft.SemanticKernel;
+
+namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Connectors;
+
+/// <inheritdoc/>
+public class SkVisionWordDocumentConnector : IEnmarchaDocumentConnector
+{
+    private readonly SkVisionImageExtractor? imageExtractor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkVisionWordDocumentConnector"/> class.
+    /// </summary>
+    /// <param name="kernel">A valid <see cref="Kernel"/> instance.</param>
+    /// <param name="options">Configuration options for vision processing.</param>
+    public SkVisionWordDocumentConnector(Kernel kernel, IOptions<SkVisionImageExtractorOptions> options)
+    {
+        Guard.IsNotNull(kernel);
+
+        this.imageExtractor = options?.Value is not null ? new SkVisionImageExtractor(kernel, options) : null;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<string> CompatibleFileFormats => [".DOCX"];
+
+    /// <inheritdoc/>
+    public virtual string ReadText(Stream stream)
+    {
+        Guard.IsNotNull(stream);
+
+        return DocxExtractorHelper.ExtractText(stream, imageExtractor);
+    }
+
+    /// <inheritdoc/>
+    public virtual void Initialize(Stream stream)
+    {
+        // Intentionally not implemented to comply with the Liskov Substitution Principle...
+    }
+
+    /// <inheritdoc/>
+    public virtual void AppendText(Stream stream, string text)
+    {
+        // Intentionally not implemented to comply with the Liskov Substitution Principle...
+    }
+}

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Encamina.Enmarcha.SemanticKernel.Connectors.Document.csproj
@@ -58,5 +58,5 @@
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
-
+    
 </Project>

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Options/SkVisionImageDocumentConnectorOptions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Options/SkVisionImageDocumentConnectorOptions.cs
@@ -5,10 +5,7 @@ namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Options;
 /// <summary>
 /// Configuration options for <see cref="SkVisionImageDocumentConnector"/>.
 /// </summary>
-public sealed class SkVisionImageDocumentConnectorOptions
+[Obsolete("This class is deprecated and will be removed in a future version. Use SkVisionImageExtractorOptions instead.")]
+public sealed class SkVisionImageDocumentConnectorOptions : SkVisionImageExtractorOptions
 {
-    /// <summary>
-    /// Gets the resolution limit (in pixels) for images.
-    /// </summary>
-    public int ResolutionLimit { get; init; } = 8192;
 }

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Options/SkVisionImageExtractorOptions.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Options/SkVisionImageExtractorOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Options;
+
+/// <summary>
+/// Configuration options for <see cref="SkVisionImageExtractor"/>.
+/// </summary>
+public class SkVisionImageExtractorOptions
+{
+    /// <summary>
+    /// Gets the resolution limit (in pixels) for images.
+    /// </summary>
+    public int ResolutionLimit { get; init; } = 8192;
+}

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/SkVisionImageExtractor.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/SkVisionImageExtractor.cs
@@ -40,10 +40,10 @@ public class SkVisionImageExtractor
         - Specific Instructions for Formatting:
 
         1. Represent diagrams or schemes using a dedicated section with discrete data in a table in Markdown format, formatted as follows:
-        [IMAGE]
+        [IMAGE][/IMAGE]
 
         2. Represent images or photos using a dedicated Markdown section with a full description of what you see, formatted as follows:
-        [PHOTO]
+        [PHOTO][/PHOTO]
 
         3. Restrain from adding any additional information or commentary. If the page is empty do not transcribe anything and just return an empty string.
 
@@ -61,14 +61,14 @@ public class SkVisionImageExtractor
     /// <summary>
     /// Configuration options for vision image processing.
     /// </summary>
-    private readonly SkVisionImageDocumentConnectorOptions options;
+    private readonly SkVisionImageExtractorOptions options;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SkVisionImageExtractor"/> class.
     /// </summary>
     /// <param name="kernel">A valid <see cref="Kernel"/> instance.</param>
     /// <param name="options">Configuration options for vision processing.</param>
-    public SkVisionImageExtractor(Kernel kernel, IOptions<SkVisionImageDocumentConnectorOptions> options)
+    public SkVisionImageExtractor(Kernel kernel, IOptions<SkVisionImageExtractorOptions> options)
     {
         chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
         this.options = options.Value;

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Utils/DocxExtractorHelper.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Utils/DocxExtractorHelper.cs
@@ -1,0 +1,137 @@
+﻿using System.Text;
+
+namespace Encamina.Enmarcha.SemanticKernel.Connectors.Document.Utils;
+
+/// <summary>
+/// A class for extracting content from DOCX files.
+/// </summary>
+internal static class DocxExtractorHelper
+{
+    /// <summary>
+    /// Extracts text from a DOCX file stream.
+    /// If use a <see cref="SkVisionImageExtractor"/>, it will process images in the document, otherwise it will ignore them.
+    /// </summary>
+    /// <param name="docxStream">Stream of the DOCX file.</param>
+    /// <param name="imageExtractor">Semantic Kernel image extractor for processing images, can be null.</param>
+    /// <returns>Extracted text with images and tables.</returns>
+    public static string ExtractText(Stream docxStream, SkVisionImageExtractor? imageExtractor = null)
+    {
+        var sb = new StringBuilder();
+        using var doc = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(docxStream, false);
+
+        if (doc.MainDocumentPart is null)
+        {
+            return sb.ToString();
+        }
+
+        var body = doc.MainDocumentPart?.Document?.Body ?? new DocumentFormat.OpenXml.Wordprocessing.Body();
+        foreach (var element in body.Elements())
+        {
+            if (element is DocumentFormat.OpenXml.Wordprocessing.Paragraph paragraph)
+            {
+                var paragraphText = ProcessParagraph(paragraph, doc.MainDocumentPart!, imageExtractor);
+                sb.AppendLine(paragraphText);
+            }
+            else if (element is DocumentFormat.OpenXml.Wordprocessing.Table table)
+            {
+                var tableText = ProcessTable(table);
+                sb.AppendLine(tableText);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string ProcessParagraph(
+        DocumentFormat.OpenXml.Wordprocessing.Paragraph paragraph,
+        DocumentFormat.OpenXml.Packaging.MainDocumentPart mainDocumentPart,
+        SkVisionImageExtractor? imageExtractor = null)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var run in paragraph.Elements<DocumentFormat.OpenXml.Wordprocessing.Run>())
+        {
+            if (imageExtractor is not null && run.Descendants<DocumentFormat.OpenXml.Wordprocessing.Drawing>().Any())
+            {
+                foreach (var drawing in run.Descendants<DocumentFormat.OpenXml.Wordprocessing.Drawing>())
+                {
+                    var blip = drawing.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().FirstOrDefault();
+                    if (blip?.Embed?.Value == null)
+                    {
+                        continue;
+                    }
+
+                    var imagePart = (DocumentFormat.OpenXml.Packaging.ImagePart)mainDocumentPart.GetPartById(blip.Embed.Value);
+
+                    // Using a System.Drawing.Image to convert the image
+                    using var imagePartStream = imagePart.GetStream(FileMode.Open, FileAccess.Read);
+                    using var image = System.Drawing.Image.FromStream(imagePartStream);
+
+                    // Convert to PNG before process with SK Vision
+                    using var pngStream = new MemoryStream();
+                    image.Save(pngStream, System.Drawing.Imaging.ImageFormat.Png);
+
+                    sb.AppendLine(imageExtractor.ProcessImageWithVision(pngStream));
+                }
+
+                continue;
+            }
+
+            var textElement = run.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.Text>();
+            if (textElement != null)
+            {
+                sb.Append(string.Format(@"{0} ", textElement.Text));
+            }
+
+            if (run.Descendants<DocumentFormat.OpenXml.Wordprocessing.Break>().Any())
+            {
+                sb.AppendLine();
+            }
+        }
+
+        foreach (var link in paragraph.Elements<DocumentFormat.OpenXml.Wordprocessing.Hyperlink>())
+        {
+            var linkText = string.Concat(link.Descendants<DocumentFormat.OpenXml.Wordprocessing.Text>()?.Select(t => t.Text) ?? []);
+            var linkUrl = string.Empty;
+            if (link.Id != null)
+            {
+                var rel = mainDocumentPart.HyperlinkRelationships.FirstOrDefault(r => r.Id == link.Id);
+                linkUrl = rel?.Uri?.ToString() ?? string.Empty;
+            }
+            else if (link.Anchor != null)
+            {
+                linkUrl = "#" + link.Anchor;
+            }
+
+            sb.AppendLine(@"[HYPERLINK]");
+            sb.AppendLine(string.Format(@"Description: {0}; Url: {1}", linkText, linkUrl));
+            sb.AppendLine(@"[/HYPERLINK]");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string ProcessTable(DocumentFormat.OpenXml.Wordprocessing.Table table)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(@"[TABLE]");
+
+        var rows = table.Elements<DocumentFormat.OpenXml.Wordprocessing.TableRow>();
+        foreach (var row in rows)
+        {
+            var cellsText = new List<string>();
+
+            var cells = row.Elements<DocumentFormat.OpenXml.Wordprocessing.TableCell>();
+            foreach (var cell in cells)
+            {
+                cellsText.Add(string.Join(@" ", cell.Descendants<DocumentFormat.OpenXml.Wordprocessing.Paragraph>().Select(p => p.InnerText.Trim())));
+            }
+
+            sb.AppendLine(string.Join(@" | ", cellsText));
+        }
+
+        sb.AppendLine(@"[/TABLE]");
+
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
Added a new connector `SkVisionWordDocumentConnector` to extract text, tables, hyperlinks and images from Word documents (.docx) using Semantic Kernel vision capabilities in image extractions. This capacity to extract the description for each image is realized using the existing `SkVisionImageExtractor`. This functionality is compatible with the previous `WordDocumentConector` implementation, so it can be used interchangeably using the `WordDocumentConnector:UseImageExtractor` setting.