### PR TITLE
Add Azure TokenCredential support to Table CosmosInitializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Previous classification is not required if changes are simple or all belong to t
   - Detects embedded images in PDF files, processes them using vision, and appends their descriptions as additional text blocks.
 - Introduced a new virtual extension point `ProcessPageExtensions(Page page)` in `StrictFormatCleanPdfDocumentConnector`, allowing derived classes to append custom content blocks to the extracted page content.
 - Added a new connector `SkVisionWordDocumentConnector` to extract text, tables, hyperlinks and images from Word documents (.docx) using Semantic Kernel vision capabilities in image extractions. This capacity to extract the description for each image is realized using the existing `SkVisionImageExtractor`. This functionality is compatible with the previous `WordDocumentConector` implementation, so it can be used interchangeably using the `WordDocumentConnector:UseImageExtractor` setting.
+- Added Azure authentication support via TokenCredential in `CosmosInitializer`.
 
 - Updated dependencies:
   - Aspire.Hosting 8.2.1 → 8.2.2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.2.1</VersionPrefix>
-    <VersionSuffix>preview-06</VersionSuffix>
+    <VersionSuffix>preview-07</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Data.Cosmos/CosmosOptions.cs
+++ b/src/Encamina.Enmarcha.Data.Cosmos/CosmosOptions.cs
@@ -19,7 +19,7 @@ public class CosmosOptions
     /// <summary>
     /// Gets or sets the authentication key required to connect with Azure Cosmos DB.
     /// </summary>
-    [RequiredIf(nameof(UseDefaultAzureCredentialAuthentication), false)]
+    [RequiredIf([nameof(UseDefaultAzureCredentialAuthentication), nameof(UseTokenCredentialAuthentication)], [false, false], failOnAnyCondition: false)]
     public string? AuthKey { get; set; }
 
     /// <summary>
@@ -97,4 +97,13 @@ public class CosmosOptions
     /// Default value is <see langword="false" />.
     /// </remarks>
     public bool UseDefaultAzureCredentialAuthentication { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether token credential authentication should be used.
+    /// When set to <see langword="true"/>, a TokenCredential must be provided to the CosmosClient constructor at run-time.
+    /// </summary>
+    /// <remarks>
+    /// Default value is <see langword="false" />.
+    /// </remarks>
+    public bool UseTokenCredentialAuthentication { get; set; } = false;
 }

--- a/src/Encamina.Enmarcha.Data.Cosmos/Resources/ExceptionMessages.Designer.cs
+++ b/src/Encamina.Enmarcha.Data.Cosmos/Resources/ExceptionMessages.Designer.cs
@@ -113,5 +113,14 @@ namespace Encamina.Enmarcha.Data.Cosmos.Resources {
                 return ResourceManager.GetString("MissingDatabaseConfigurationParameterException", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TokenCredential cannot be null when UseTokenCredentialAuthentication is true..
+        /// </summary>
+        internal static string TokenCredentialCannotBeNullException {
+            get {
+                return ResourceManager.GetString("TokenCredentialCannotBeNullException", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Encamina.Enmarcha.Data.Cosmos/Resources/ExceptionMessages.es.resx
+++ b/src/Encamina.Enmarcha.Data.Cosmos/Resources/ExceptionMessages.es.resx
@@ -135,4 +135,7 @@
   <data name="MissingDatabaseConfigurationParameterException" xml:space="preserve">
     <value>¡Falta el parámetro de configuración 'Base de datos'!</value>
   </data>
+  <data name="TokenCredentialCannotBeNullException" xml:space="preserve">
+    <value>'TokenCredential' no puede ser nulo cuando 'UseTokenCredentialAuthentication' es true.</value>
+  </data>
 </root>

--- a/src/Encamina.Enmarcha.Data.Cosmos/Resources/ExceptionMessages.resx
+++ b/src/Encamina.Enmarcha.Data.Cosmos/Resources/ExceptionMessages.resx
@@ -135,4 +135,7 @@
   <data name="MissingDatabaseConfigurationParameterException" xml:space="preserve">
     <value>Missing 'Database' configuration parameter!</value>
   </data>
+  <data name="TokenCredentialCannotBeNullException" xml:space="preserve">
+    <value>TokenCredential cannot be null when UseTokenCredentialAuthentication is true.</value>
+  </data>
 </root>


### PR DESCRIPTION
This pull request introduces Azure authentication support via TokenCredential for accessing to CosmosDB.

- `CosmosInitializer.cs`: Added support for `TokenCredential` authentication and refactored client creation logic.
- `CosmosOptions.cs`: Introduced a new property for token credential authentication.
- `IServiceCollectionExtensions.cs`: Updated methods to support the new authentication mechanism.