### PR TITLE
Add Azure TokenCredential support to Azure AI Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ Previous classification is not required if changes are simple or all belong to t
 - Introduced a new virtual extension point `ProcessPageExtensions(Page page)` in `StrictFormatCleanPdfDocumentConnector`, allowing derived classes to append custom content blocks to the extracted page content.
 - Added a new connector `SkVisionWordDocumentConnector` to extract text, tables, hyperlinks and images from Word documents (.docx) using Semantic Kernel vision capabilities in image extractions. This capacity to extract the description for each image is realized using the existing `SkVisionImageExtractor`. This functionality is compatible with the previous `WordDocumentConector` implementation, so it can be used interchangeably using the `WordDocumentConnector:UseImageExtractor` setting.
 - Added Azure authentication support via TokenCredential in `CosmosInitializer`.
-
+- Added Azure authentication support via TokenCredential in Azure AI Search.
+ 
 - Updated dependencies:
   - Aspire.Hosting 8.2.1 → 8.2.2
   - Azure.AI.OpenAI 2.1.0-beta.1 → 2.2.0-beta.1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.2.1</VersionPrefix>
-    <VersionSuffix>preview-07</VersionSuffix>
+    <VersionSuffix>preview-08</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Data.AzureAISearch/AzureAISearchOptions.cs
+++ b/src/Encamina.Enmarcha.Data.AzureAISearch/AzureAISearchOptions.cs
@@ -19,6 +19,15 @@ public sealed class AzureAISearchOptions
     /// <summary>
     /// Gets the Azure AI Search key.
     /// </summary>
-    [Required]
-    public required string Key { get; init; }
+    [RequiredIf(nameof(UseTokenCredentialAuthentication), false)]
+    public string? Key { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether token credential authentication should be used.
+    /// When set to <see langword="true"/>, a TokenCredential must be provided to the Azure AI Search client constructor at run-time.
+    /// </summary>
+    /// <remarks>
+    /// Default value is <see langword="false" />.
+    /// </remarks>
+    public bool UseTokenCredentialAuthentication { get; set; } = false;
 }


### PR DESCRIPTION
This pull request introduces Azure authentication support via TokenCredential for accessing to Azure AI Search.

- AzureAISearchOptions.cs: Introduced a new property for token credential authentication.
- IServiceCollectionExtensions.cs: Updated methods to support the new authentication mechanism.