### PR TITLE
Add AuthorizationScope to AzureOpenAIOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Previous classification is not required if changes are simple or all belong to t
     - Microsoft.SemanticKernel.Abstractions 1.42.0 -> 1.64.0
 
 ### Minor Changes
+- Added `AuthorizationScope` property to `AzureOpenAIOptions` to specify the authorization scope.
+
+### Minor Changes
 - Removed `Encamina.Enmarcha.Samples.SemanticKernel.QuestionAnswering` project.
 
 ## [8.2.1]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>8.3.0</VersionPrefix>
-    <VersionSuffix>preview-01</VersionSuffix>
+    <VersionSuffix>preview-02</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.AI.OpenAI.Azure/AzureOpenAIOptions.cs
+++ b/src/Encamina.Enmarcha.AI.OpenAI.Azure/AzureOpenAIOptions.cs
@@ -48,4 +48,10 @@ public sealed class AzureOpenAIOptions : OpenAIOptionsBase
     /// Gets the token credentials options to authenticate to an LLM resource.
     /// </summary>
     public TokenCredentialsOptions? TokenCredentialsOptions { get; init; }
+
+    /// <summary>
+    /// Gets the authorization scope for authentication when authenticating with Azure authentication tokens.
+    /// If not specified, defaults authorization scopes will be used.
+    /// </summary>
+    public string? AuthorizationScope { get; init; }
 }


### PR DESCRIPTION
- Introduced the AuthorizationScope property to AzureOpenAIOptions for specifying the authorization scope when using Azure authentication tokens. 
- Updated version suffix to preview-02 in Directory.Build.props and documented the change in CHANGELOG.md.