### PR TITLE
Update `TelemetryInitializerMiddleware` and `TelemetryAgentIdInitializer` to work with Agents 365 SDK

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>10.0.0</VersionPrefix>
-    <VersionSuffix>preview-03</VersionSuffix>
+    <VersionSuffix>preview-04</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Agents/Middlewares/TelemetryInitializerMiddleware.cs
+++ b/src/Encamina.Enmarcha.Agents/Middlewares/TelemetryInitializerMiddleware.cs
@@ -1,40 +1,39 @@
-﻿using System.Text.Json;
+﻿using CommunityToolkit.Diagnostics;
 
-using CommunityToolkit.Diagnostics;
-
+using Encamina.Enmarcha.Agents.Models;
 using Encamina.Enmarcha.Agents.Telemetry;
 
 using Microsoft.Agents.Builder;
-using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 using IMiddleware = Microsoft.Agents.Builder.IMiddleware;
 
 namespace Encamina.Enmarcha.Agents.Middlewares;
 
 /// <summary>
-/// Middleware for storing incoming activity on the HttpContext to make it available to the <see cref="TelemetryAgentIdInitializer"/>.
+/// Middleware for storing incoming activity to make it available to the <see cref="TelemetryAgentIdInitializer"/>.
 /// </summary>
 public class TelemetryInitializerMiddleware : IMiddleware
 {
-    private readonly IHttpContextAccessor httpContextAccessor;
     private readonly TelemetryLoggerMiddleware telemetryLoggerMiddleware;
+    private readonly ILogger<TelemetryInitializerMiddleware> logger;
     private readonly bool logActivityTelemetry;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryInitializerMiddleware"/> class.
     /// </summary>
-    /// <param name="httpContextAccessor">The IHttpContextAccessor to allow access to the HttpContext.</param>
     /// <param name="telemetryLoggerMiddleware">The TelemetryLoggerMiddleware to allow for logging of activity events.</param>
+    /// <param name="logger">The logger to use to log information.</param>
     /// <param name="logActivityTelemetry">Indicates if the TelemetryLoggerMiddleware should be executed to log activity events.</param>
-    public TelemetryInitializerMiddleware(IHttpContextAccessor httpContextAccessor, TelemetryLoggerMiddleware telemetryLoggerMiddleware, bool logActivityTelemetry = true)
+    public TelemetryInitializerMiddleware(TelemetryLoggerMiddleware telemetryLoggerMiddleware, ILogger<TelemetryInitializerMiddleware> logger, bool logActivityTelemetry = true)
     {
-        this.httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         this.telemetryLoggerMiddleware = telemetryLoggerMiddleware;
+        this.logger = logger;
         this.logActivityTelemetry = logActivityTelemetry;
     }
 
     /// <summary>
-    /// Stores the incoming activity as JSON in the items collection on the HttpContext.
+    /// Stores relevant information from the incoming activity in the <see cref="TelemetryAgentIdInitializer"/>.
     /// </summary>
     /// <param name="context">The context object for this turn.</param>
     /// <param name="nextTurn">The delegate to call to continue the agent middleware pipeline.</param>
@@ -43,33 +42,52 @@ public class TelemetryInitializerMiddleware : IMiddleware
     /// <returns>A task that represents the work queued to execute.</returns>
     /// <seealso cref="ITurnContext"/>
     /// <seealso cref="Microsoft.Agents.Core.Models.IActivity"/>
-    public virtual async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+    public async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
     {
         Guard.IsNotNull(context);
 
         if (context.Activity != null)
         {
-            var activity = context.Activity;
+            // Create and set context for this async flow
+            var telemetryContext = AgentTelemetryContext.FromActivity(context.Activity);
+            TelemetryAgentIdInitializer.SetCurrentContext(telemetryContext);
 
-            var httpContext = httpContextAccessor.HttpContext;
-            var items = httpContext?.Items;
+            logger.LogDebug("Telemetry context set for RequestId: {RequestId}", context.Activity.RequestId);
 
-            var activityJson = JsonSerializer.SerializeToNode(activity);
-
-            items?.Remove(TelemetryAgentIdInitializer.AgentActivityKey);
-
-            items?.Add(TelemetryAgentIdInitializer.AgentActivityKey, activityJson);
-        }
-
-        if (logActivityTelemetry)
-        {
-            await telemetryLoggerMiddleware
-                .OnTurnAsync(context, nextTurn, cancellationToken)
-                .ConfigureAwait(false);
+            try
+            {
+                if (logActivityTelemetry)
+                {
+                    await telemetryLoggerMiddleware
+                        .OnTurnAsync(context, nextTurn, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await nextTurn(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                // Clear context after turn completion
+                TelemetryAgentIdInitializer.ClearCurrentContext();
+                logger.LogDebug("Telemetry context cleared for RequestId: {RequestId}", context.Activity.RequestId);
+            }
         }
         else
         {
-            await nextTurn(cancellationToken).ConfigureAwait(false);
+            logger.LogWarning("Activity is null, telemetry context not set");
+
+            if (logActivityTelemetry)
+            {
+                await telemetryLoggerMiddleware
+                    .OnTurnAsync(context, nextTurn, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await nextTurn(cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Encamina.Enmarcha.Agents/Models/AgentTelemetryContext.cs
+++ b/src/Encamina.Enmarcha.Agents/Models/AgentTelemetryContext.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Agents.Core.Models;
+
+namespace Encamina.Enmarcha.Agents.Models;
+
+/// <summary>
+/// Represents telemetry context information extracted from an Agent activity.
+/// </summary>
+internal sealed class AgentTelemetryContext
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the user who sent the activity.
+    /// </summary>
+    public string UserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the conversation identifier associated with the activity.
+    /// </summary>
+    public string ConversationId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the unique identifier of the activity.
+    /// </summary>
+    public string ActivityId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the channel identifier through which the activity arrived.
+    /// </summary>
+    public string ChannelId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the type of the activity.
+    /// </summary>
+    public string ActivityType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the request identifier correlated with the activity.
+    /// </summary>
+    public string RequestId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Creates an <see cref="AgentTelemetryContext"/> from an <see cref="IActivity"/> instance.
+    /// </summary>
+    /// <param name="activity">The source activity used to populate telemetry details.</param>
+    /// <returns>An <see cref="AgentTelemetryContext"/> populated with activity metadata.</returns>
+    public static AgentTelemetryContext FromActivity(IActivity activity)
+    {
+        if (activity == null)
+        {
+            return new AgentTelemetryContext();
+        }
+
+        var context = new AgentTelemetryContext
+        {
+            ActivityId = activity.Id ?? string.Empty,
+            ChannelId = activity.ChannelId ?? string.Empty,
+            ActivityType = activity.Type?.ToString() ?? string.Empty,
+            RequestId = activity.RequestId ?? string.Empty,
+        };
+
+        if (activity.From?.Id != null)
+        {
+            context.UserId = activity.From.Id;
+        }
+
+        if (activity.Conversation?.Id != null)
+        {
+            context.ConversationId = activity.Conversation.Id;
+        }
+
+        return context;
+    }
+}

--- a/src/Encamina.Enmarcha.Agents/Telemetry/TelemetryAgentIdInitializer.cs
+++ b/src/Encamina.Enmarcha.Agents/Telemetry/TelemetryAgentIdInitializer.cs
@@ -1,11 +1,9 @@
-﻿using System.Text.Json;
-
+﻿using Encamina.Enmarcha.Agents.Models;
 using Encamina.Enmarcha.Core.Extensions;
 
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.AspNetCore.Http;
 
 namespace Encamina.Enmarcha.Agents.Telemetry;
 
@@ -14,20 +12,22 @@ namespace Encamina.Enmarcha.Agents.Telemetry;
 /// </summary>
 public class TelemetryAgentIdInitializer : ITelemetryInitializer
 {
-    /// <summary>
-    /// Constant key used for storing activity information in turn state.
-    /// </summary>
-    public const string AgentActivityKey = "AgentActivity";
-
-    private readonly IHttpContextAccessor httpContextAccessor;
+    private static readonly AsyncLocal<AgentTelemetryContext> CurrentContext = new();
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="TelemetryAgentIdInitializer"/> class.
+    /// Sets the current telemetry context for the async flow.
     /// </summary>
-    /// <param name="httpContextAccessor">The HttpContextAccessor used to access the current HttpContext.</param>
-    public TelemetryAgentIdInitializer(IHttpContextAccessor httpContextAccessor)
+    internal static void SetCurrentContext(AgentTelemetryContext context)
     {
-        this.httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+        CurrentContext.Value = context;
+    }
+
+    /// <summary>
+    /// Clears the current telemetry context.
+    /// </summary>
+    internal static void ClearCurrentContext()
+    {
+        CurrentContext.Value = null;
     }
 
     /// <inheritdoc/>
@@ -38,52 +38,28 @@ public class TelemetryAgentIdInitializer : ITelemetryInitializer
             return;
         }
 
-        var httpContext = httpContextAccessor.HttpContext;
-        var items = httpContext?.Items;
-
-        if (items != null)
+        var context = CurrentContext.Value;
+        if (context == null)
         {
-            if (telemetry is RequestTelemetry or EventTelemetry or TraceTelemetry or DependencyTelemetry or PageViewTelemetry
-                && items.TryGetValue(AgentActivityKey, out var agentActivity) && agentActivity is JsonElement body)
+            return;
+        }
+
+        if (telemetry is RequestTelemetry or EventTelemetry or TraceTelemetry or DependencyTelemetry or PageViewTelemetry)
+        {
+            // Set Application Insights standard properties
+            telemetry.Context.User.Id = $"{context.ChannelId}{context.UserId}";
+            telemetry.Context.Session.Id = context.ConversationId.Hash();
+
+            // Set custom properties
+            if (telemetry is ISupportProperties propertiesTelemetry)
             {
-                var userId = string.Empty;
-                if (body.TryGetProperty("from", out var from) && from.TryGetProperty("id", out var fromId))
-                {
-                    userId = fromId.GetString() ?? string.Empty;
-                }
+                var properties = propertiesTelemetry.Properties;
 
-                var channelId = body.GetProperty("channelId").GetString();
-
-                var conversationId = string.Empty;
-                var sessionId = string.Empty;
-                if (body.TryGetProperty("conversation", out var conversation) && conversation.TryGetProperty("id", out var convId))
-                {
-                    conversationId = convId.GetString() ?? string.Empty;
-                    sessionId = conversationId.Hash();
-                }
-
-                // Set the user id on the Application Insights telemetry item.
-                telemetry.Context.User.Id = channelId + userId;
-
-                // Set the session id on the Application Insights telemetry item.
-                // Hashed ID is used due to max session ID length for App Insights session Id
-                telemetry.Context.Session.Id = sessionId;
-
-                var telemetryProperties = ((ISupportProperties)telemetry).Properties;
-
-                telemetryProperties.TryAdd("conversationId", conversationId);
-
-                if (!telemetryProperties.ContainsKey("activityId"))
-                {
-                    telemetryProperties.Add("activityId", body.GetProperty("id").GetString());
-                }
-
-                telemetryProperties.TryAdd("channelId", channelId);
-
-                if (!telemetryProperties.ContainsKey("activityType"))
-                {
-                    telemetryProperties.Add("activityType", body.GetProperty("type").GetString());
-                }
+                properties.TryAdd("conversationId", context.ConversationId);
+                properties.TryAdd("activityId", context.ActivityId);
+                properties.TryAdd("channelId", context.ChannelId);
+                properties.TryAdd("activityType", context.ActivityType);
+                properties.TryAdd("requestId", context.RequestId);
             }
         }
     }

--- a/src/Encamina.Enmarcha.Agents/Telemetry/TelemetryAgentIdInitializer.cs
+++ b/src/Encamina.Enmarcha.Agents/Telemetry/TelemetryAgentIdInitializer.cs
@@ -12,23 +12,7 @@ namespace Encamina.Enmarcha.Agents.Telemetry;
 /// </summary>
 public class TelemetryAgentIdInitializer : ITelemetryInitializer
 {
-    private static readonly AsyncLocal<AgentTelemetryContext> CurrentContext = new();
-
-    /// <summary>
-    /// Sets the current telemetry context for the async flow.
-    /// </summary>
-    internal static void SetCurrentContext(AgentTelemetryContext context)
-    {
-        CurrentContext.Value = context;
-    }
-
-    /// <summary>
-    /// Clears the current telemetry context.
-    /// </summary>
-    internal static void ClearCurrentContext()
-    {
-        CurrentContext.Value = null;
-    }
+    private static readonly AsyncLocal<AgentTelemetryContext?> CurrentContext = new();
 
     /// <inheritdoc/>
     public void Initialize(ITelemetry telemetry)
@@ -62,5 +46,22 @@ public class TelemetryAgentIdInitializer : ITelemetryInitializer
                 properties.TryAdd("requestId", context.RequestId);
             }
         }
+    }
+
+    /// <summary>
+    /// Sets the current telemetry context for the async flow.
+    /// </summary>
+    /// <param name="context">The telemetry context to set.</param>
+    internal static void SetCurrentContext(AgentTelemetryContext context)
+    {
+        CurrentContext.Value = context;
+    }
+
+    /// <summary>
+    /// Clears the current telemetry context.
+    /// </summary>
+    internal static void ClearCurrentContext()
+    {
+        CurrentContext.Value = null;
     }
 }


### PR DESCRIPTION
# Description

Updated `TelemetryInitializerMiddleware` and `TelemetryAgentIdInitializer` to work with Agents 365 SDK.

## Motivation and Context

Because the Agents 365 SDK queues activities for asynchronous processing, the original `HttpContext` of the request is lost during activity handling. Both `TelemetryInitializerMiddleware` and `TelemetryAgentIdInitializer` were previously tied to this `HttpContext` to propagate relevant activity information.

The new changes replace the use of `HttpContext` with an `AsyncLocal<AgentTelemetryContext>` to maintain this propagation capability.

## Type of change

Please check only those options that are relevant with a (✅).

- [X] The code builds clean without any errors or warnings
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

Please check all options from this checklist when validating your pull request with a (✅).

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I didn't break anyone :smile:
