### PR TITLE
Implement telemetry correlation in M365 Agents SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ Previous classification is not required if changes are simple or all belong to t
 
 ### Breaking Changes
 - Removed `Encamina.Enmarcha.Bot`, `Encamina.Enmarcha.Bot.Abstractions` and `Encamina.Enmarcha.Bot.Skills.QuestionAnswering` projects.
+- Added the new `CorrelationRehydrationMiddleware` to `DefaultMiddlewareUseRules`. This middleware rehydrates correlations from incoming activities in M365 Agents SDK.
 
 ### Major Changes
 - Added `Encamina.Enmarcha.AI.Agents`, `Encamina.Enmarcha.AI.Agents.Abstractions` and `Encamina.Enmarcha.Agents.Skills.QuestionAnswering` projects to provide support for the new Microsoft 365 Agents SDK.
+- Added `ICorrelationStore` and `DistributedCacheCorrelationStore` to store correlations (`CorrelationEntry`) in a distributed cache.
 
 ## [8.3.0]
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>10.0.0</VersionPrefix>
-    <VersionSuffix>preview-04</VersionSuffix>
+    <VersionSuffix>preview-05</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Agents.Abstractions/Telemetry/CorrelationEntry.cs
+++ b/src/Encamina.Enmarcha.Agents.Abstractions/Telemetry/CorrelationEntry.cs
@@ -1,0 +1,8 @@
+﻿namespace Encamina.Enmarcha.Agents.Abstractions.Telemetry;
+
+/// <summary>
+/// Represents a correlation entry containing trace information.
+/// </summary>
+/// <param name="TraceParent">The W3C traceparent value.</param>
+/// <param name="TraceState">The W3C tracestate value (optional).</param>
+public sealed record CorrelationEntry(string TraceParent, string? TraceState);

--- a/src/Encamina.Enmarcha.Agents.Abstractions/Telemetry/ICorrelationStore.cs
+++ b/src/Encamina.Enmarcha.Agents.Abstractions/Telemetry/ICorrelationStore.cs
@@ -1,0 +1,27 @@
+﻿namespace Encamina.Enmarcha.Agents.Abstractions.Telemetry;
+
+/// <summary>
+/// Defines methods for storing and retrieving correlation information for conversations and activities.
+/// </summary>
+public interface ICorrelationStore
+{
+    /// <summary>
+    /// Stores a correlation entry for a given conversation and activity with a specified time-to-live (TTL).
+    /// </summary>
+    /// <param name="conversationId">The unique identifier for the conversation.</param>
+    /// <param name="activityId">The unique identifier for the activity.</param>
+    /// <param name="entry">The correlation entry to store.</param>
+    /// <param name="ttl">The time-to-live for the entry.</param>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    ValueTask SetAsync(string conversationId, string activityId, CorrelationEntry entry, TimeSpan ttl, CancellationToken ct);
+
+    /// <summary>
+    /// Retrieves a correlation entry for a given conversation and activity.
+    /// </summary>
+    /// <param name="conversationId">The unique identifier for the conversation.</param>
+    /// <param name="activityId">The unique identifier for the activity.</param>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns>The correlation entry if found; otherwise, <c>null</c>.</returns>
+    ValueTask<CorrelationEntry?> GetAsync(string conversationId, string activityId, CancellationToken ct);
+}

--- a/src/Encamina.Enmarcha.Agents.Abstractions/Telemetry/TelemetryConstants.cs
+++ b/src/Encamina.Enmarcha.Agents.Abstractions/Telemetry/TelemetryConstants.cs
@@ -1,7 +1,7 @@
 ﻿namespace Encamina.Enmarcha.Agents.Abstractions.Telemetry;
 
 /// <summary>
-/// Defines names of common properties for use with a <see cref="IAgentTelemetryClient"/> object.
+/// Defines names of common properties for use in telemety.
 /// </summary>
 public static class TelemetryConstants
 {
@@ -84,4 +84,14 @@ public static class TelemetryConstants
     /// The telemetry property value for activity id.
     /// </summary>
     public const string ActivityIdProperty = "activityId";
+
+    /// <summary>
+    /// The telemetry property value for request id.
+    /// </summary>
+    public const string RequestIdProperty = "requestId";
+
+    /// <summary>
+    /// The name of the activity source used by the telemetry of the bot.
+    /// </summary>
+    public const string BotActivitySource = "BotActivitySource";
 }

--- a/src/Encamina.Enmarcha.Agents/Adapters/ChannelCloudAdapterWithErrorHandlerBase.cs
+++ b/src/Encamina.Enmarcha.Agents/Adapters/ChannelCloudAdapterWithErrorHandlerBase.cs
@@ -23,6 +23,7 @@ public class ChannelCloudAdapterWithErrorHandlerBase : CloudAdapter
     /// </summary>
     public static readonly IReadOnlyList<IMiddlewareUseRule> DefaultMiddlewareUseRules = new List<IMiddlewareUseRule>()
     {
+        new MiddlewareUseRule<CorrelationRehydrationMiddleware>() { Order = 5 },
         new MiddlewareUseRule<TelemetryInitializerMiddleware>() { Order = 10 }, // IMPORTANT - This middleware calls 'TelemetryLoggerMiddleware'. Adding 'TelemetryLoggerMiddleware' as middleware will produce repeated log entries.
         new MiddlewareUseRule<TranscriptLoggerMiddleware>() { Order = 20 },
         new MiddlewareUseRule<ShowTypingMiddleware>() { Order = 30 },

--- a/src/Encamina.Enmarcha.Agents/Middlewares/CorrelationRehydrationMiddleware.cs
+++ b/src/Encamina.Enmarcha.Agents/Middlewares/CorrelationRehydrationMiddleware.cs
@@ -48,7 +48,7 @@ public sealed class CorrelationRehydrationMiddleware : IMiddleware
         {
             if (!string.IsNullOrEmpty(convId) && !string.IsNullOrEmpty(actId))
             {
-                var corr = await store.GetAsync(convId!, actId!, cancellationToken);
+                var corr = await store.GetAsync(convId, actId, cancellationToken);
                 if (corr is not null && !string.IsNullOrWhiteSpace(corr.TraceParent))
                 {
                     var parent = ActivityContext.Parse(corr.TraceParent, corr.TraceState);

--- a/src/Encamina.Enmarcha.Agents/Middlewares/CorrelationRehydrationMiddleware.cs
+++ b/src/Encamina.Enmarcha.Agents/Middlewares/CorrelationRehydrationMiddleware.cs
@@ -1,0 +1,75 @@
+﻿using System.Diagnostics;
+
+using Encamina.Enmarcha.Agents.Abstractions.Telemetry;
+
+using Microsoft.Agents.Builder;
+
+namespace Encamina.Enmarcha.Agents.Middlewares;
+
+/// <summary>
+/// Middleware that restores distributed correlation information for incoming bot activities.
+/// </summary>
+/// <remarks>
+/// Retrieves a <see cref="CorrelationEntry"/> from an <see cref="ICorrelationStore"/>
+/// using the incoming activity’s conversation and activity IDs.
+/// If correlation data is found, it parses the stored W3C <c>traceparent</c> and <c>tracestate</c>,
+/// builds an <see cref="ActivityContext"/>, and starts a <see cref="Activity"/> using the internal <see cref="ActivitySource"/>.
+/// If no correlation data is available, it starts a fallback internal activity instead.
+/// The activity is automatically stopped when the turn completes.
+///
+/// <para>
+/// The <see cref="ActivitySource"/> defined in <see cref="TelemetryConstants.BotActivitySource"/> 
+/// must be registered in the application to enable full trace correlation.
+/// </para>
+/// </remarks>
+public sealed class CorrelationRehydrationMiddleware : IMiddleware
+{
+    private static readonly ActivitySource Source = new(TelemetryConstants.BotActivitySource);
+    private readonly ICorrelationStore store;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CorrelationRehydrationMiddleware"/> class.
+    /// </summary>
+    /// <param name="store">The correlation store used to retrieve stored correlation entries.</param>
+    public CorrelationRehydrationMiddleware(ICorrelationStore store)
+    {
+        this.store = store;
+    }
+
+    /// <inheritdoc />
+    public async Task OnTurnAsync(ITurnContext context, NextDelegate next, CancellationToken cancellationToken)
+    {
+        Activity? activity = null;
+
+        var convId = context.Activity?.Conversation?.Id;
+        var actId = context.Activity?.Id;
+
+        try
+        {
+            if (!string.IsNullOrEmpty(convId) && !string.IsNullOrEmpty(actId))
+            {
+                var corr = await store.GetAsync(convId!, actId!, cancellationToken);
+                if (corr is not null && !string.IsNullOrWhiteSpace(corr.TraceParent))
+                {
+                    var parent = ActivityContext.Parse(corr.TraceParent, corr.TraceState);
+                    activity = Source.StartActivity("OnTurnAsync", ActivityKind.Consumer, parent);
+
+                    activity?.AddBaggage(TelemetryConstants.ConversationIdProperty, convId!);
+                    activity?.AddBaggage(TelemetryConstants.ActivityIdProperty, actId!);
+
+                    activity?.SetTag(TelemetryConstants.ConversationIdProperty, convId);
+                    activity?.SetTag(TelemetryConstants.ActivityIdProperty, actId);
+                    activity?.SetTag(TelemetryConstants.ChannelIdProperty, context.Activity?.ChannelId);
+                    activity?.SetTag(TelemetryConstants.ActivityTypeProperty, context.Activity?.Type);
+                    activity?.SetTag(TelemetryConstants.UserIdProperty, context.Activity?.From?.Id);
+                }
+            }
+
+            await next(cancellationToken);
+        }
+        finally
+        {
+            activity?.Stop();
+        }
+    }
+}

--- a/src/Encamina.Enmarcha.Agents/Telemetry/DistributedCacheCorrelationStore.cs
+++ b/src/Encamina.Enmarcha.Agents/Telemetry/DistributedCacheCorrelationStore.cs
@@ -1,0 +1,78 @@
+﻿using Encamina.Enmarcha.Agents.Abstractions.Telemetry;
+
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Encamina.Enmarcha.Agents.Telemetry;
+
+/// <summary>
+/// An implementation of <see cref="ICorrelationStore"/> using <see cref="IDistributedCache"/>.
+/// </summary>
+public sealed class DistributedCacheCorrelationStore : ICorrelationStore
+{
+    private readonly IDistributedCache cache;
+    private readonly string prefix;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DistributedCacheCorrelationStore"/> class.
+    /// </summary>
+    /// <param name="cache">A distributed cache instance.</param>
+    /// <param name="keyPrefix">A prefix to use for cache keys.</param>
+    public DistributedCacheCorrelationStore(IDistributedCache cache, string keyPrefix = "corr:")
+    {
+        this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        prefix = keyPrefix;
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask SetAsync(string conversationId, string activityId, CorrelationEntry entry, TimeSpan ttl, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(conversationId) || string.IsNullOrWhiteSpace(activityId))
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(entry.TraceParent))
+        {
+            return;
+        }
+
+        var key = Key(conversationId, activityId);
+        var value = Pack(entry.TraceParent, entry.TraceState);
+
+        var opts = new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = ttl,
+        };
+
+        await cache.SetStringAsync(key, value, opts, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<CorrelationEntry?> GetAsync(string conversationId, string activityId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(conversationId) || string.IsNullOrWhiteSpace(activityId))
+        {
+            return null;
+        }
+
+        var key = Key(conversationId, activityId);
+        var packed = await cache.GetStringAsync(key, ct).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(packed))
+        {
+            return null;
+        }
+
+        var (tp, ts) = Unpack(packed);
+        return new CorrelationEntry(tp, ts);
+    }
+
+    private static string Pack(string tp, string? ts) => string.IsNullOrWhiteSpace(ts) ? tp : $"{tp}|{ts}";
+
+    private static (string Tp, string? Ts) Unpack(string s)
+    {
+        var i = s.IndexOf('|');
+        return i < 0 ? (s, null) : (s[..i], s[(i + 1)..]);
+    }
+
+    private string Key(string conv, string act) => $"{prefix}{conv}:{act}";
+}

--- a/src/Encamina.Enmarcha.Agents/Telemetry/TelemetryAgentIdInitializer.cs
+++ b/src/Encamina.Enmarcha.Agents/Telemetry/TelemetryAgentIdInitializer.cs
@@ -1,4 +1,5 @@
-﻿using Encamina.Enmarcha.Agents.Models;
+﻿using Encamina.Enmarcha.Agents.Abstractions.Telemetry;
+using Encamina.Enmarcha.Agents.Models;
 using Encamina.Enmarcha.Core.Extensions;
 
 using Microsoft.ApplicationInsights.Channel;
@@ -39,11 +40,11 @@ public class TelemetryAgentIdInitializer : ITelemetryInitializer
             {
                 var properties = propertiesTelemetry.Properties;
 
-                properties.TryAdd("conversationId", context.ConversationId);
-                properties.TryAdd("activityId", context.ActivityId);
-                properties.TryAdd("channelId", context.ChannelId);
-                properties.TryAdd("activityType", context.ActivityType);
-                properties.TryAdd("requestId", context.RequestId);
+                properties.TryAdd(TelemetryConstants.ConversationIdProperty, context.ConversationId);
+                properties.TryAdd(TelemetryConstants.ActivityIdProperty, context.ActivityId);
+                properties.TryAdd(TelemetryConstants.ChannelIdProperty, context.ChannelId);
+                properties.TryAdd(TelemetryConstants.ActivityTypeProperty, context.ActivityType);
+                properties.TryAdd(TelemetryConstants.RequestIdProperty, context.RequestId);
             }
         }
     }


### PR DESCRIPTION
# Description

- Added the new `CorrelationRehydrationMiddleware` to `DefaultMiddlewareUseRules`. This middleware rehydrates correlations from incoming activities in M365 Agents SDK.
- Added `ICorrelationStore` and `DistributedCacheCorrelationStore` to store correlations (`CorrelationEntry`) in a distributed cache.


## Motivation and Context

Following the previous PR, we need to refactor trace management so that the request can be traced with the activity queued and processed asynchronously by M365 Agents SDK.

## Type of change

Please check only those options that are relevant with a (✅).

- [X] The code builds clean without any errors or warnings
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

Please check all options from this checklist when validating your pull request with a (✅).

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I didn't break anyone :smile:
