### PR TITLE
Migrating common utils from Avolta Project

### DIFF
--- a/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
+++ b/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
@@ -150,7 +150,7 @@ public sealed class LiveActivityManager
 
             return new Attachment
             {
-                ContentType = Encamina.Enmarcha.Net.Http.MediaTypeNames.Application.AdaptativeCard,
+                ContentType = Encamina.Enmarcha.Net.Http.MediaTypeNames.Application.AdaptiveCard,
                 Content = JsonSerializer.Deserialize<object>(jsonEmpty, jsonSerializerOptions),
             };
         }
@@ -196,7 +196,7 @@ public sealed class LiveActivityManager
 
         return new Attachment
         {
-            ContentType = Encamina.Enmarcha.Net.Http.MediaTypeNames.Application.AdaptativeCard,
+            ContentType = Encamina.Enmarcha.Net.Http.MediaTypeNames.Application.AdaptiveCard,
             Content = JsonSerializer.Deserialize<object>(json, jsonSerializerOptions),
         };
     }

--- a/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
+++ b/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
@@ -118,7 +118,7 @@ public sealed class LiveActivityManager
     private async Task<LiveActivityEntry?> GetEntryAsync(string liveActivityId, CancellationToken ct)
     {
         var json = await cache.GetStringAsync(CacheKey(liveActivityId), ct);
-        return string.IsNullOrEmpty(json) ? null : JsonSerializer.Deserialize<LiveActivityEntry>(json);
+        return string.IsNullOrEmpty(json) ? null : JsonSerializer.Deserialize<LiveActivityEntry>(json, jsonSerializerOptions);
     }
 
     private Task SaveEntryAsync(LiveActivityEntry entry, CancellationToken ct)

--- a/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
+++ b/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
@@ -1,0 +1,233 @@
+﻿using System.Text.Json;
+
+using AdaptiveCards.Templating;
+
+using Encamina.Enmarcha.Agents.Models;
+using Encamina.Enmarcha.Agents.Options;
+
+using Encamina.Enmarcha.Conversation.Abstractions;
+
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Extensions.Teams;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Encamina.Enmarcha.Agents.Activities;
+
+/// <summary>
+/// Manages live activities by handling updates, maintaining history, generating adaptive cards, and sending/updating activities.
+/// </summary>
+public sealed class LiveActivityManager
+{
+    private readonly IIntentResponsesProvider intentResponsesProvider;
+
+    private readonly IDistributedCache cache;
+
+    private readonly ILogger<LiveActivityManager> logger;
+
+    private readonly JsonSerializerOptions jsonSerializerOptions;
+
+    private LiveActivityManagerOptions options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LiveActivityManager"/> class.
+    /// </summary>
+    /// <param name="intentResponsesProvider">Provider for localized intent responses.</param>
+    /// <param name="cache">Distributed cache for storing live activity entries.</param>
+    /// <param name="optionsMonitor">Options monitor for <see cref="LiveActivityManagerOptions"/>.</param>
+    /// <param name="logger">A logger for this class.</param>
+    public LiveActivityManager(IIntentResponsesProvider intentResponsesProvider, IDistributedCache cache, IOptionsMonitor<LiveActivityManagerOptions> optionsMonitor, ILogger<LiveActivityManager> logger)
+    {
+        this.intentResponsesProvider = intentResponsesProvider;
+        this.cache = cache;
+        this.logger = logger;
+
+        options = optionsMonitor.CurrentValue;
+        optionsMonitor.OnChange(o => options = o);
+
+        jsonSerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString,
+        };
+    }
+
+    /// <summary>
+    /// Handles an update to a live activity, updating its history, generating an adaptive card, and sending/updating the activity.
+    /// </summary>
+    /// <param name="turnContext">The turn context for the current bot activity.</param>
+    /// <param name="req">The live activity update request containing the update details.</param>
+    /// <param name="channelId">The channel ID (e.g., "msteams", "ems", "directline", "webchat").</param>
+    /// <param name="ct">A cancellation token for the async operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task HandleUpdateAsync(ITurnContext turnContext, LiveActivityUpdateRequest req, string channelId, CancellationToken ct)
+    {
+        var channelIsCopilot = channelId.Equals(Channels.M365Copilot);
+
+        var entry = await GetEntryAsync(req.LiveActivityId, ct) ?? new LiveActivityEntry { LiveActivityId = req.LiveActivityId };
+
+        // Limited history
+        entry.History.Add(req);
+        if (entry.History.Count > options.HistoryLimit)
+        {
+            var toRemove = entry.History.Count - options.HistoryLimit;
+            entry.History.RemoveRange(0, toRemove);
+        }
+
+        await SendNowAsync(turnContext, entry, channelIsCopilot, ct);
+
+        await SaveEntryAsync(entry, ct);
+    }
+
+    private static string CacheKey(string liveActivityId) => $"liveactivity:{liveActivityId}";
+
+    private static string? FixNewLines(string? text) => text?.Replace(@"\\n", Environment.NewLine);
+
+    private async Task SendNowAsync(ITurnContext turnContext, LiveActivityEntry entry, bool channelIsCopilot, CancellationToken ct)
+    {
+        // Copilot: if not finished, don't update (it will be updated when finished)
+        if (channelIsCopilot && entry.History.Last().Status == LiveActivityStatus.Running)
+        {
+            return;
+        }
+
+        // Copilot finished, or normal Teams: create or update card
+        var attachment = await BuildCardAttachment(entry.History, turnContext.Activity.Locale, channelIsCopilot, ct);
+
+        // Create activity if needed. (Cause we don't persist ActivityId for Copilot, it will be always null there)
+        if (string.IsNullOrEmpty(entry.ActivityId))
+        {
+            var message = MessageFactory.Attachment(attachment);
+            message.TeamsNotifyUser();
+            var rr = await turnContext.SendActivityAsync(message, ct);
+            entry.ActivityId = rr.Id;
+
+            return;
+        }
+
+        // Update activity otherwise
+        var update = MessageFactory.Attachment(attachment);
+        var act = (Activity)update;
+        act.Id = entry.ActivityId;
+
+        await turnContext.UpdateActivityAsync(act, ct);
+    }
+
+    private async Task<LiveActivityEntry?> GetEntryAsync(string liveActivityId, CancellationToken ct)
+    {
+        var json = await cache.GetStringAsync(CacheKey(liveActivityId), ct);
+        return string.IsNullOrEmpty(json) ? null : JsonSerializer.Deserialize<LiveActivityEntry>(json);
+    }
+
+    private Task SaveEntryAsync(LiveActivityEntry entry, CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(entry);
+        var opts = new DistributedCacheEntryOptions { SlidingExpiration = options.CacheSlidingExpiration };
+        return cache.SetStringAsync(CacheKey(entry.LiveActivityId), json, opts, ct);
+    }
+
+    private async Task<Attachment> BuildCardAttachment(IReadOnlyList<LiveActivityUpdateRequest> history, string locale, bool channelIsCopilot, CancellationToken ct)
+    {
+        if (history == null || history.Count == 0)
+        {
+            var jsonEmpty = new AdaptiveCardTemplate(options.LiveTemplateJson).Expand(new
+            {
+                title = string.Empty,
+                subtitle = (string?)null,
+                content = (string?)null,
+                statusText = "Unknown",
+                statusColor = "default",
+                statusGlyph = "❔",
+                progressPercentText = (string?)null,
+                showProgress = false,
+                showStatusBar = !channelIsCopilot,
+                isRunning = false,
+                hasHistory = false,
+                history = Array.Empty<object>(),
+            });
+
+            return new Attachment
+            {
+                ContentType = Encamina.Enmarcha.Net.Http.MediaTypeNames.Application.AdaptativeCard,
+                Content = JsonSerializer.Deserialize<object>(jsonEmpty, jsonSerializerOptions),
+            };
+        }
+
+        // Current
+        var current = history[^1];
+        var (currText, currColor, currGlyph) = await MapStatus(current.Status, locale, ct);
+        var currHasProgress = current.ProgressPercent.HasValue;
+        var currPercent = Math.Clamp(current.ProgressPercent ?? 0, 0, 100);
+
+        // Past
+        var past = new List<object>(Math.Max(0, history.Count - 1));
+        for (var i = 0; i <= history.Count - 2; i++)
+        {
+            var it = history[i];
+            past.Add(new
+            {
+                stepText = $"{i + 1}.",
+                title = FixNewLines(it.Title),
+                content = FixNewLines(it.Content),
+                subtitle = FixNewLines(it.Subtitle),
+            });
+        }
+
+        var json = new AdaptiveCardTemplate(options.LiveTemplateJson).Expand(new
+        {
+            // Current
+            title = FixNewLines(current.Title),
+            subtitle = FixNewLines(current.Subtitle),
+            content = FixNewLines(current.Content),
+            statusText = currText,
+            statusColor = currColor,
+            statusGlyph = currGlyph,
+            progressPercentText = currHasProgress ? $"{currPercent}%" : null,
+            showProgress = currHasProgress,
+            showStatusBar = !channelIsCopilot,
+            isRunning = current.Status == LiveActivityStatus.Running,
+
+            // History
+            hasHistory = past.Count > 0 && current.ShowHistory,
+            history = past,
+        });
+
+        return new Attachment
+        {
+            ContentType = Encamina.Enmarcha.Net.Http.MediaTypeNames.Application.AdaptativeCard,
+            Content = JsonSerializer.Deserialize<object>(json, jsonSerializerOptions),
+        };
+    }
+
+    private async Task<(string Text, string Color, string Glyph)> MapStatus(LiveActivityStatus s, string locale, CancellationToken ct)
+    {
+        var responses = await intentResponsesProvider.GetResponsesAsync(s.ToString(), locale, ct);
+        var translatedText = responses.FirstOrDefault()?.Text;
+
+        if (string.IsNullOrEmpty(translatedText))
+        {
+            logger.LogWarning("No translation found for status {Status} and locale {Locale}. Falling back to enum name.", s, locale);
+            translatedText = s.ToString();
+        }
+
+        return s switch
+        {
+            LiveActivityStatus.Running => (translatedText, "accent", "⏳"),
+            LiveActivityStatus.Completed => (translatedText, "good", "✅"),
+            LiveActivityStatus.Warning => (translatedText, "warning", "⚠️"),
+            LiveActivityStatus.Failed => (translatedText, "attention", "❌"),
+            _ => (translatedText, "default", "❔"),
+        };
+    }
+
+    private sealed class LiveActivityEntry
+    {
+        public required string LiveActivityId { get; init; }
+
+        public string? ActivityId { get; set; }
+
+        public List<LiveActivityUpdateRequest> History { get; init; } = [];
+    }
+}

--- a/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
+++ b/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
@@ -64,7 +64,7 @@ public sealed class LiveActivityManager
     /// <returns>A task representing the asynchronous operation.</returns>
     public async Task HandleUpdateAsync(ITurnContext turnContext, LiveActivityUpdateRequest req, string channelId, CancellationToken ct)
     {
-        var channelIsCopilot = channelId.Equals(Channels.M365Copilot);
+        var channelIsCopilot = channelId.Equals(Channels.M365Copilot, StringComparison.OrdinalIgnoreCase);
 
         var entry = await GetEntryAsync(req.LiveActivityId, ct) ?? new LiveActivityEntry { LiveActivityId = req.LiveActivityId };
 

--- a/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
+++ b/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
@@ -150,7 +150,7 @@ public sealed class LiveActivityManager
 
             return new Attachment
             {
-                ContentType = Encamina.Enmarcha.Net.Http.MediaTypeNames.Application.AdaptiveCard,
+                ContentType = Encamina.Enmarcha.Net.Http.MediaTypeNames.Application.AdaptativeCard,
                 Content = JsonSerializer.Deserialize<object>(jsonEmpty, jsonSerializerOptions),
             };
         }
@@ -196,7 +196,7 @@ public sealed class LiveActivityManager
 
         return new Attachment
         {
-            ContentType = Encamina.Enmarcha.Net.Http.MediaTypeNames.Application.AdaptiveCard,
+            ContentType = Encamina.Enmarcha.Net.Http.MediaTypeNames.Application.AdaptativeCard,
             Content = JsonSerializer.Deserialize<object>(json, jsonSerializerOptions),
         };
     }

--- a/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
+++ b/src/Encamina.Enmarcha.Agents/Activities/LiveActivityManager.cs
@@ -64,7 +64,7 @@ public sealed class LiveActivityManager
     /// <returns>A task representing the asynchronous operation.</returns>
     public async Task HandleUpdateAsync(ITurnContext turnContext, LiveActivityUpdateRequest req, string channelId, CancellationToken ct)
     {
-        var channelIsCopilot = channelId.Equals(Channels.M365Copilot, StringComparison.OrdinalIgnoreCase);
+        var channelIsCopilot = channelId.Equals(Channels.M365Copilot);
 
         var entry = await GetEntryAsync(req.LiveActivityId, ct) ?? new LiveActivityEntry { LiveActivityId = req.LiveActivityId };
 

--- a/src/Encamina.Enmarcha.Agents/CommonConstants.cs
+++ b/src/Encamina.Enmarcha.Agents/CommonConstants.cs
@@ -43,21 +43,21 @@ public static class CommonConstants
         /// <summary>
         /// Gets the custom header that represents an activity id.
         /// </summary>
-        public const string HeaderActivityId = @"x-avolta-activity-id";
+        public const string HeaderActivityId = @"x-bot-activity-id";
 
         /// <summary>
         /// Gets the custom header that represents a conversation id.
         /// </summary>
-        public const string HeaderConversationId = @"x-avolta-conversation-id";
+        public const string HeaderConversationId = @"x-bot-conversation-id";
 
         /// <summary>
         /// Gets the custom header that represents a user email.
         /// </summary>
-        public const string HeaderUserEmail = @"x-avolta-user-email";
+        public const string HeaderUserEmail = @"x-bot-user-email";
 
         /// <summary>
         /// Gets the custom header that represents a user id.
         /// </summary>
-        public const string HeaderUserId = @"x-avolta-user-id";
+        public const string HeaderUserId = @"x-bot-user-id";
     }
 }

--- a/src/Encamina.Enmarcha.Agents/CommonConstants.cs
+++ b/src/Encamina.Enmarcha.Agents/CommonConstants.cs
@@ -1,0 +1,63 @@
+﻿namespace Encamina.Enmarcha.Agents;
+
+/// <summary>
+/// Static class that defines common constants used in the application.
+/// </summary>
+public static class CommonConstants
+{
+    /// <summary>
+    /// Correlation items used in the application.
+    /// </summary>
+    public static class LogAIRequestScopeItems
+    {
+        /// <summary>
+        /// Gets the correlation item key for the activity ID.
+        /// </summary>
+        public const string ActivityId = @"ActivityId";
+
+        /// <summary>
+        /// Gets the correlation item key for the conversation ID.
+        /// </summary>
+        public const string ConversationId = @"ConversationId";
+
+        /// <summary>
+        /// Gets the correlation item key for the user ID.
+        /// </summary>
+        public const string UserId = @"UserId";
+
+        /// <summary>
+        /// Gets the correlation item key for the user email.
+        /// </summary>
+        public const string UserEmail = @"UserEmail";
+
+        /// <summary>
+        /// Gets the endpoint group name for AI-related functionalities.
+        /// </summary>
+        public const string AI = @"ai";
+
+        /// <summary>
+        /// Gets the endpoint group name for management-related functionalities.
+        /// </summary>
+        public const string Management = @"management";
+
+        /// <summary>
+        /// Gets the custom header that represents an activity id.
+        /// </summary>
+        public const string HeaderActivityId = @"x-avolta-activity-id";
+
+        /// <summary>
+        /// Gets the custom header that represents a conversation id.
+        /// </summary>
+        public const string HeaderConversationId = @"x-avolta-conversation-id";
+
+        /// <summary>
+        /// Gets the custom header that represents a user email.
+        /// </summary>
+        public const string HeaderUserEmail = @"x-avolta-user-email";
+
+        /// <summary>
+        /// Gets the custom header that represents a user id.
+        /// </summary>
+        public const string HeaderUserId = @"x-avolta-user-id";
+    }
+}

--- a/src/Encamina.Enmarcha.Agents/Encamina.Enmarcha.Agents.csproj
+++ b/src/Encamina.Enmarcha.Agents/Encamina.Enmarcha.Agents.csproj
@@ -9,13 +9,16 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
       <PackageReference Include="Azure.Data.Tables" Version="12.10.0" />
+      <PackageReference Include="Encamina.Enmarcha.Net.Http" Version="10.0.0-preview-06" />
       <PackageReference Include="Microsoft.Agents.Builder.Dialogs" Version="1.2.41" />
       <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.2.41" />
       <PackageReference Include="Microsoft.Agents.Storage.Blobs" Version="1.2.41" />
       <PackageReference Include="Microsoft.Agents.Storage.CosmosDb" Version="1.2.41" />
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
+      <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.Agents/Encamina.Enmarcha.Agents.csproj
+++ b/src/Encamina.Enmarcha.Agents/Encamina.Enmarcha.Agents.csproj
@@ -11,7 +11,6 @@
     <ItemGroup>
       <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
       <PackageReference Include="Azure.Data.Tables" Version="12.10.0" />
-      <PackageReference Include="Encamina.Enmarcha.Net.Http" Version="10.0.0-preview-06" />
       <PackageReference Include="Microsoft.Agents.Builder.Dialogs" Version="1.2.41" />
       <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.2.41" />
       <PackageReference Include="Microsoft.Agents.Storage.Blobs" Version="1.2.41" />
@@ -30,6 +29,7 @@
       <ProjectReference Include="..\Encamina.Enmarcha.Conversation\Encamina.Enmarcha.Conversation.csproj" />
       <ProjectReference Include="..\Encamina.Enmarcha.Core\Encamina.Enmarcha.Core.csproj" />
       <ProjectReference Include="..\Encamina.Enmarcha.DependencyInjection\Encamina.Enmarcha.DependencyInjection.csproj" />
+      <ProjectReference Include="..\Encamina.Enmarcha.Net.Http\Encamina.Enmarcha.Net.Http.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.Agents/Extensions/HttpContextExtensions.cs
+++ b/src/Encamina.Enmarcha.Agents/Extensions/HttpContextExtensions.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Encamina.Enmarcha.Agents.Extensions;
+
+/// <summary>
+/// Extension methods for HttpContext related operations.
+/// </summary>
+public static class HttpContextExtensions
+{
+    private const string NotAvailable = @"N/A";
+
+    /// <summary>
+    /// Gets the first value of the specified header from the request's headers. Returns the specified default value if the header is not present.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> instance.</param>
+    /// <param name="headerName">The name of the header to retrieve.</param>
+    /// <param name="defaultValue">The default value to return if the header is not present.</param>
+    /// <returns>The value of the specified header or the default value if the header is not present.</returns>
+    public static string GetRequestHeaderValueOrDefault(this HttpContext? context, string headerName, string defaultValue = NotAvailable)
+    {
+        return context != null && context.Request.Headers.TryGetValue(headerName, out var values) ? values.FirstOrDefault() ?? defaultValue : defaultValue;
+    }
+
+    /// <summary>
+    /// Tries to get the value of the specified header from the request's headers.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> instance.</param>
+    /// <param name="headerName">The name of the header to retrieve.</param>
+    /// <param name="value">The value of the specified header, if present; otherwise, an empty string.</param>
+    /// <returns>True if the header is present, false otherwise.</returns>
+    public static bool TryGetRequestHeaderValue(this HttpContext? context, string headerName, out string value)
+    {
+        if (context != null && context.Request.Headers.TryGetValue(headerName, out var values))
+        {
+            var firstNonNullValue = values.FirstOrDefault(v => v != null);
+
+            if (firstNonNullValue != null)
+            {
+                value = firstNonNullValue;
+                return true;
+            }
+        }
+
+        value = string.Empty;
+        return false;
+    }
+}

--- a/src/Encamina.Enmarcha.Agents/Filters/AgentCustomEventsFilter.cs
+++ b/src/Encamina.Enmarcha.Agents/Filters/AgentCustomEventsFilter.cs
@@ -1,0 +1,120 @@
+﻿using System.Diagnostics;
+
+using Encamina.Enmarcha.Agents.Models;
+
+using Microsoft.ApplicationInsights;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Encamina.Enmarcha.Agents.Filters;
+
+/// <summary>
+/// Action filter that generates custom events for AIController requests with AgentRequest parameters.
+/// </summary>
+public class AgentCustomEventsFilter : IActionFilter
+{
+    private const string TimestampKey = "CustomEventsFilter_Timestamp";
+    private const string ActionStartEvent = "AgentStart";
+    private const string ActionEndEvent = "AgentEnd";
+    private const string ActionErrorEvent = "AgentError";
+
+    private readonly TelemetryClient telemetryClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentCustomEventsFilter"/> class.
+    /// </summary>
+    /// <param name="telemetryClient">The Application Insights telemetry client.</param>
+    public AgentCustomEventsFilter(TelemetryClient telemetryClient)
+    {
+        this.telemetryClient = telemetryClient;
+    }
+
+    /// <summary>
+    /// Called before the action executes.
+    /// </summary>
+    /// <param name="context">The action executing context.</param>
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+        if (!ShouldTrack(context))
+        {
+            return;
+        }
+
+        context.HttpContext.Items[TimestampKey] = Stopwatch.GetTimestamp();
+
+        var properties = new Dictionary<string, string>();
+
+        var agentRequest = context.ActionArguments.Values.OfType<AgentRequest>().FirstOrDefault();
+        if (agentRequest is not null)
+        {
+            properties["Input"] = agentRequest.Input;
+            properties["Locale"] = agentRequest.Locale;
+        }
+
+        telemetryClient.TrackEvent(ActionStartEvent, properties);
+    }
+
+    /// <summary>
+    /// Called after the action executes.
+    /// </summary>
+    /// <param name="context">The action executed context.</param>
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+        if (!ShouldTrack(context) ||
+            !context.HttpContext.Items.TryGetValue(TimestampKey, out var startTimestampObj) ||
+            startTimestampObj is not long startTimestamp)
+        {
+            return;
+        }
+
+        var durationMs = Stopwatch.GetElapsedTime(startTimestamp, Stopwatch.GetTimestamp()).TotalMilliseconds;
+        var properties = new Dictionary<string, string>
+        {
+            { "DurationMs", durationMs.ToString("F2") },
+        };
+
+        var statusCode = context.HttpContext.Response.StatusCode;
+        properties["StatusCode"] = statusCode.ToString();
+
+        // Track error event if status code is not 200
+        if (statusCode != StatusCodes.Status200OK)
+        {
+            var errorProperties = new Dictionary<string, string>(properties);
+
+            if (context.Exception is not null)
+            {
+                errorProperties["ExceptionType"] = context.Exception.GetType().Name;
+                errorProperties["ExceptionMessage"] = context.Exception.Message;
+            }
+
+            if (context.Result is Microsoft.AspNetCore.Mvc.ObjectResult { Value: not null } errorResult)
+            {
+                errorProperties["ErrorResponse"] = errorResult.Value.ToString() ?? string.Empty;
+            }
+
+            telemetryClient.TrackEvent(ActionErrorEvent, errorProperties);
+        }
+
+        if (context.Result is Microsoft.AspNetCore.Mvc.ObjectResult { Value: not null } objectResult)
+        {
+            var textProperty = objectResult.Value.GetType().GetProperty("Text");
+            if (textProperty?.GetValue(objectResult.Value) is string textValue && !string.IsNullOrEmpty(textValue))
+            {
+                properties["Output"] = textValue;
+            }
+        }
+
+        telemetryClient.TrackEvent(ActionEndEvent, properties);
+        context.HttpContext.Items.Remove(TimestampKey);
+    }
+
+    /// <summary>
+    /// Determines if the request should be tracked based on controller name and parameter types.
+    /// </summary>
+    /// <param name="context">The filter context.</param>
+    /// <returns>True if the request should be tracked; otherwise, false.</returns>
+    private static bool ShouldTrack(FilterContext context) =>
+        context.ActionDescriptor.RouteValues.TryGetValue("controller", out var controller) &&
+        controller?.Equals("AI", StringComparison.OrdinalIgnoreCase) == true &&
+        context.ActionDescriptor.Parameters.Any(p => typeof(AgentRequest).IsAssignableFrom(p.ParameterType));
+}

--- a/src/Encamina.Enmarcha.Agents/Middlewares/LogAIRequestScopeMiddleware.cs
+++ b/src/Encamina.Enmarcha.Agents/Middlewares/LogAIRequestScopeMiddleware.cs
@@ -38,12 +38,13 @@ internal sealed class LogAIRequestScopeMiddleware
                 .GetMetadata<Microsoft.AspNetCore.Routing.EndpointGroupNameAttribute>()?
                 .EndpointGroupName == CommonConstants.LogAIRequestScopeItems.AI)
         {
-            var scopeState = new Dictionary<string, object> {
-            { CommonConstants.LogAIRequestScopeItems.ActivityId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderActivityId) },
-            { CommonConstants.LogAIRequestScopeItems.ConversationId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderConversationId) },
-            { CommonConstants.LogAIRequestScopeItems.UserId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderUserId) },
-            { CommonConstants.LogAIRequestScopeItems.UserEmail, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderUserEmail) },
-        };
+            var scopeState = new Dictionary<string, object>
+            {
+                { CommonConstants.LogAIRequestScopeItems.ActivityId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderActivityId) },
+                { CommonConstants.LogAIRequestScopeItems.ConversationId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderConversationId) },
+                { CommonConstants.LogAIRequestScopeItems.UserId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderUserId) },
+                { CommonConstants.LogAIRequestScopeItems.UserEmail, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderUserEmail) },
+            };
 
             using var _ = logger.BeginScope(scopeState);
             await next(context);

--- a/src/Encamina.Enmarcha.Agents/Middlewares/LogAIRequestScopeMiddleware.cs
+++ b/src/Encamina.Enmarcha.Agents/Middlewares/LogAIRequestScopeMiddleware.cs
@@ -1,0 +1,57 @@
+﻿using Encamina.Enmarcha.Agents.Extensions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Encamina.Enmarcha.Agents.Middlewares;
+
+/// <summary>
+/// Middleware that adds structured logging scope for AI-related requests.
+/// It extracts specific headers from the request (e.g., ActivityId, UserId)
+/// and includes them in the log scope for better traceability.
+/// </summary>
+internal sealed class LogAIRequestScopeMiddleware
+{
+    private readonly RequestDelegate next;
+    private readonly ILogger<LogAIRequestScopeMiddleware> logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LogAIRequestScopeMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The next middleware in the HTTP request pipeline.</param>
+    /// <param name="logger">The logger instance used to log information.</param>
+    public LogAIRequestScopeMiddleware(RequestDelegate next, ILogger<LogAIRequestScopeMiddleware> logger)
+    {
+        this.next = next;
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// Invokes the middleware to log the request scope for AI-related endpoints.
+    /// If the request targets an AI endpoint, a logging scope is created with relevant request data.
+    /// </summary>
+    /// <param name="context">The HTTP context of the request.</param>
+    /// <returns>A task representing the completion of request processing.</returns>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.GetEndpoint()?.Metadata
+                .GetMetadata<Microsoft.AspNetCore.Routing.EndpointGroupNameAttribute>()?
+                .EndpointGroupName == CommonConstants.LogAIRequestScopeItems.AI)
+        {
+            var scopeState = new Dictionary<string, object>
+        {
+            { CommonConstants.LogAIRequestScopeItems.ActivityId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderActivityId) },
+            { CommonConstants.LogAIRequestScopeItems.ConversationId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderConversationId) },
+            { CommonConstants.LogAIRequestScopeItems.UserId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderUserId) },
+            { CommonConstants.LogAIRequestScopeItems.UserEmail, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderUserEmail) },
+        };
+
+            using var _ = logger.BeginScope(scopeState);
+            await next(context);
+        }
+        else
+        {
+            await next(context);
+        }
+    }
+}

--- a/src/Encamina.Enmarcha.Agents/Middlewares/LogAIRequestScopeMiddleware.cs
+++ b/src/Encamina.Enmarcha.Agents/Middlewares/LogAIRequestScopeMiddleware.cs
@@ -38,8 +38,7 @@ internal sealed class LogAIRequestScopeMiddleware
                 .GetMetadata<Microsoft.AspNetCore.Routing.EndpointGroupNameAttribute>()?
                 .EndpointGroupName == CommonConstants.LogAIRequestScopeItems.AI)
         {
-            var scopeState = new Dictionary<string, object>
-        {
+            var scopeState = new Dictionary<string, object> {
             { CommonConstants.LogAIRequestScopeItems.ActivityId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderActivityId) },
             { CommonConstants.LogAIRequestScopeItems.ConversationId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderConversationId) },
             { CommonConstants.LogAIRequestScopeItems.UserId, context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderUserId) },

--- a/src/Encamina.Enmarcha.Agents/Models/AgentRequest.cs
+++ b/src/Encamina.Enmarcha.Agents/Models/AgentRequest.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Encamina.Enmarcha.Agents.Models;
+
+/// <summary>
+/// Common request for all AI Agents.
+/// </summary>
+public class AgentRequest
+{
+    /// <summary>
+    /// Gets the user inquiry.
+    /// </summary>
+    [Required]
+    [SwaggerParameter("The user inquiry, input or request.")]
+    public virtual string Input { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the locale of the user.
+    /// </summary>
+    [Required]
+    [SwaggerParameter("The language of the user.")]
+    public virtual string Locale { get; init; } = string.Empty;
+}

--- a/src/Encamina.Enmarcha.Agents/Models/LiveActivityStatus.cs
+++ b/src/Encamina.Enmarcha.Agents/Models/LiveActivityStatus.cs
@@ -1,0 +1,27 @@
+﻿namespace Encamina.Enmarcha.Agents.Models;
+
+/// <summary>
+/// Represents the status of a live activity.
+/// </summary>
+public enum LiveActivityStatus
+{
+    /// <summary>
+    /// The activity is currently running.
+    /// </summary>
+    Running = 0,
+
+    /// <summary>
+    /// The activity has completed successfully.
+    /// </summary>
+    Completed = 1,
+
+    /// <summary>
+    /// The activity has failed.
+    /// </summary>
+    Failed = 2,
+
+    /// <summary>
+    /// The activity has completed with warnings.
+    /// </summary>
+    Warning = 3,
+}

--- a/src/Encamina.Enmarcha.Agents/Models/LiveActivityUpdateRequest.cs
+++ b/src/Encamina.Enmarcha.Agents/Models/LiveActivityUpdateRequest.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Encamina.Enmarcha.Agents.Models;
+﻿namespace Encamina.Enmarcha.Agents.Models;
 
 /// <summary>
 /// Represents a request to update the state of a live activity.
@@ -14,11 +12,11 @@ namespace Encamina.Enmarcha.Agents.Models;
 /// <param name="Subtitle">
 /// An optional subtitle providing additional context for the live activity.
 /// </param>
-/// <param name="Status">
-/// The current status of the live activity.
-/// </param>
 /// <param name="Content">
 /// The main content or message of the live activity. Supports markdown.
+/// </param>
+/// <param name="Status">
+/// The current status of the live activity.
 /// </param>
 /// <param name="ProgressPercent">
 /// The progress of the live activity as a percentage (0-100). Null if not applicable.

--- a/src/Encamina.Enmarcha.Agents/Models/LiveActivityUpdateRequest.cs
+++ b/src/Encamina.Enmarcha.Agents/Models/LiveActivityUpdateRequest.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Encamina.Enmarcha.Agents.Models;
+
+/// <summary>
+/// Represents a request to update the state of a live activity.
+/// </summary>
+/// <param name="LiveActivityId">
+/// The unique identifier of the live activity to update.
+/// </param>
+/// <param name="Title">
+/// The main title or description of the live activity.
+/// </param>
+/// <param name="Subtitle">
+/// An optional subtitle providing additional context for the live activity.
+/// </param>
+/// <param name="Status">
+/// The current status of the live activity.
+/// </param>
+/// <param name="Content">
+/// The main content or message of the live activity. Supports markdown.
+/// </param>
+/// <param name="ProgressPercent">
+/// The progress of the live activity as a percentage (0-100). Null if not applicable.
+/// </param>
+/// <param name="ShowHistory">
+/// Indicates whether to show the history of the live activity.
+/// </param>
+public record LiveActivityUpdateRequest(
+  string LiveActivityId,
+  string Title,
+  string? Subtitle,
+  string? Content,
+  LiveActivityStatus Status,
+  int? ProgressPercent,
+  bool ShowHistory = true);

--- a/src/Encamina.Enmarcha.Agents/Models/LiveActivityUpdateRequest.cs
+++ b/src/Encamina.Enmarcha.Agents/Models/LiveActivityUpdateRequest.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Encamina.Enmarcha.Agents.Models;
 

--- a/src/Encamina.Enmarcha.Agents/Options/LiveActivityManagerOptions.cs
+++ b/src/Encamina.Enmarcha.Agents/Options/LiveActivityManagerOptions.cs
@@ -10,7 +10,7 @@ public class LiveActivityManagerOptions
     /// <summary>
     /// Gets the maximum number of history entries to retain for a live activity.
     /// </summary>
-    public required int HistoryLimit { get; init; }
+    public int HistoryLimit { get; init; } = 50;
 
     /// <summary>
     /// Gets the sliding expiration duration for cached live activity entries.

--- a/src/Encamina.Enmarcha.Agents/Options/LiveActivityManagerOptions.cs
+++ b/src/Encamina.Enmarcha.Agents/Options/LiveActivityManagerOptions.cs
@@ -1,0 +1,165 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Encamina.Enmarcha.Agents.Options;
+
+/// <summary>
+/// Configuration options for <see cref="Activities.LiveActivityManager"/>.
+/// </summary>
+public class LiveActivityManagerOptions
+{
+    /// <summary>
+    /// Gets the maximum number of history entries to retain for a live activity.
+    /// </summary>
+    public required int HistoryLimit { get; init; } = 50;
+
+    /// <summary>
+    /// Gets the sliding expiration duration for cached live activity entries.
+    /// </summary>
+    public required TimeSpan CacheSlidingExpiration { get; init; } = TimeSpan.FromHours(3);
+
+    /// <summary>
+    /// Gets the JSON template for adaptive cards.
+    /// </summary>
+    [Required]
+    public required string LiveTemplateJson { get; init; } = /*lang=json*/ """
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "msteams": { "width": "full" },
+  "body": [
+    {
+      "type": "Container",
+      "spacing": "Medium",
+      "separator": true,
+      "$when": "${hasHistory == true}",
+      "items": [
+        {
+          "type": "Container",
+          "$data": "${history}",
+          "items": [
+            {
+              "type": "Container",
+              "spacing": "Small",
+              "separator": true,
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        { "type": "TextBlock", "text": "${stepText}", "weight": "Bolder", "color": "accent" }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        { "type": "TextBlock", "text": "${title}", "wrap": true, "size": "Medium", "maxLines": 2 }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "id": "histDown_${$index}",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        { "type": "TextBlock", "text": "▾", "size": "Large" }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "id": "histUp_${$index}",
+                      "width": "auto",
+                      "isVisible": false,
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        { "type": "TextBlock", "text": "▴", "size": "Large" }
+                      ]
+                    }
+                  ],
+                  "selectAction": {
+                    "type": "Action.ToggleVisibility",
+                    "targetElements": [
+                      "histContent_${$index}",
+                      "histUp_${$index}",
+                      "histDown_${$index}"
+                    ]
+                  }
+                },
+                {
+                  "type": "Container",
+                  "id": "histContent_${$index}",
+                  "isVisible": false,
+                  "style": "emphasis",
+                  "spacing": "Small",
+                  "items": [
+                    { "type": "TextBlock", "text": "${subtitle}", "wrap": true, "spacing": "None", "$when": "${subtitle != null}" },
+                    { "type": "TextBlock", "text": "${content}", "isSubtle": true, "wrap": true, "$when": "${content != null}" }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "type": "Container",
+      "style": "emphasis",
+      "bleed": true,
+      "items": [
+        { "type": "TextBlock", "text": "${title}", "size": "Medium", "weight": "Bolder", "wrap": true, "maxLines": 2 },
+        { "type": "TextBlock", "text": "${subtitle}", "isSubtle": true, "wrap": true, "spacing": "None", "maxLines": 1, "$when": "${subtitle != null}" }
+      ]
+    },
+    { "type": "TextBlock", "text": "${content}", "wrap": true, "spacing": "Medium", "$when": "${content != null}" },
+
+    {
+      "type": "ColumnSet",
+      "spacing": "Medium",
+      "$when": "${showStatusBar == true}",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "auto",
+          "verticalContentAlignment": "Center",
+          "items": [
+            { "type": "TextBlock", "text": "${statusGlyph}", "size": "Large", "$when": "${isRunning != true}" },
+            {
+              "type": "ProgressRing",
+              "$when": "${isRunning == true}",
+              "fallback": { "type": "TextBlock", "text": "⏳", "size": "Large" }
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "stretch",
+          "verticalContentAlignment": "Center",
+          "items": [
+            { "type": "TextBlock", "text": "${statusText}", "weight": "Bolder", "size": "Large", "color": "${statusColor}", "wrap": true }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "horizontalAlignment": "Right",
+          "verticalContentAlignment": "Center",
+          "$when": "${showProgress == true}",
+          "items": [
+            { "type": "TextBlock", "text": "${progressPercentText}", "size": "Large", "weight": "Bolder", "horizontalAlignment": "Right" }
+          ]
+        }
+      ]
+    }
+  ],
+  "fallbackText": "This card requires Adaptive Cards 1.5."
+}
+""";
+}

--- a/src/Encamina.Enmarcha.Agents/Options/LiveActivityManagerOptions.cs
+++ b/src/Encamina.Enmarcha.Agents/Options/LiveActivityManagerOptions.cs
@@ -15,7 +15,7 @@ public class LiveActivityManagerOptions
     /// <summary>
     /// Gets the sliding expiration duration for cached live activity entries.
     /// </summary>
-    public required TimeSpan CacheSlidingExpiration { get; init; } = TimeSpan.FromHours(3);
+    public TimeSpan CacheSlidingExpiration { get; init; } = TimeSpan.FromHours(3);
 
     /// <summary>
     /// Gets the JSON template for adaptive cards.

--- a/src/Encamina.Enmarcha.Agents/Options/LiveActivityManagerOptions.cs
+++ b/src/Encamina.Enmarcha.Agents/Options/LiveActivityManagerOptions.cs
@@ -10,7 +10,7 @@ public class LiveActivityManagerOptions
     /// <summary>
     /// Gets the maximum number of history entries to retain for a live activity.
     /// </summary>
-    public required int HistoryLimit { get; init; } = 50;
+    public required int HistoryLimit { get; init; }
 
     /// <summary>
     /// Gets the sliding expiration duration for cached live activity entries.

--- a/src/Encamina.Enmarcha.Agents/Telemetry/AssemblyNameTelemetryInitializer.cs
+++ b/src/Encamina.Enmarcha.Agents/Telemetry/AssemblyNameTelemetryInitializer.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Encamina.Enmarcha.Agents.Telemetry;
+
+/// <summary>
+/// Telemetry initializer that adds the assembly name to all custom events.
+/// </summary>
+public class AssemblyNameTelemetryInitializer : ITelemetryInitializer
+{
+    private readonly string assemblyName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssemblyNameTelemetryInitializer"/> class.
+    /// </summary>
+    /// <param name="assemblyName">The name of the assembly to include in telemetry.</param>
+    public AssemblyNameTelemetryInitializer(string assemblyName)
+    {
+        this.assemblyName = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
+    }
+
+    /// <summary>
+    /// Initializes the telemetry item by adding the assembly name to custom events.
+    /// </summary>
+    /// <param name="telemetry">The telemetry item to initialize.</param>
+    public void Initialize(ITelemetry telemetry)
+    {
+        if (telemetry is EventTelemetry eventTelemetry)
+        {
+            eventTelemetry.Properties["AssemblyName"] = assemblyName;
+        }
+    }
+}

--- a/src/Encamina.Enmarcha.Agents/Telemetry/LogAIRequestScopeTelemetryInitializer.cs
+++ b/src/Encamina.Enmarcha.Agents/Telemetry/LogAIRequestScopeTelemetryInitializer.cs
@@ -1,0 +1,63 @@
+﻿using Encamina.Enmarcha.Agents.Extensions;
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Http;
+
+namespace Encamina.Enmarcha.Agents.Telemetry;
+
+/// <summary>
+/// Telemetry initializer that adds AI request correlation data to Application Insights telemetry.
+/// It extracts specific headers from the HTTP request (e.g., ActivityId, ConversationId, UserId, UserEmail)
+/// and includes them as custom properties in telemetry for better traceability.
+/// </summary>
+public class LogAIRequestScopeTelemetryInitializer : ITelemetryInitializer
+{
+    private readonly IHttpContextAccessor httpContextAccessor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LogAIRequestScopeTelemetryInitializer"/> class.
+    /// </summary>
+    /// <param name="httpContextAccessor">The HTTP context accessor to retrieve request headers.</param>
+    public LogAIRequestScopeTelemetryInitializer(IHttpContextAccessor httpContextAccessor)
+    {
+        this.httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+    }
+
+    /// <summary>
+    /// Initializes the telemetry item by adding AI request correlation data as custom properties.
+    /// </summary>
+    /// <param name="telemetry">The telemetry item to initialize.</param>
+    public void Initialize(ITelemetry telemetry)
+    {
+        var context = httpContextAccessor.HttpContext;
+
+        if (context == null)
+        {
+            return;
+        }
+
+        if (context.GetEndpoint()?.Metadata
+                .GetMetadata<Microsoft.AspNetCore.Routing.EndpointGroupNameAttribute>()?
+                .EndpointGroupName != CommonConstants.LogAIRequestScopeItems.AI)
+        {
+            return;
+        }
+
+        if (telemetry is ISupportProperties telemetryWithProperties)
+        {
+            telemetryWithProperties.Properties[CommonConstants.LogAIRequestScopeItems.ActivityId] =
+                context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderActivityId);
+
+            telemetryWithProperties.Properties[CommonConstants.LogAIRequestScopeItems.ConversationId] =
+                context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderConversationId);
+
+            telemetryWithProperties.Properties[CommonConstants.LogAIRequestScopeItems.UserId] =
+                context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderUserId);
+
+            telemetryWithProperties.Properties[CommonConstants.LogAIRequestScopeItems.UserEmail] =
+                context.GetRequestHeaderValueOrDefault(CommonConstants.LogAIRequestScopeItems.HeaderUserEmail);
+        }
+    }
+}

--- a/src/Encamina.Enmarcha.Core/StringToBooleanConverter.cs
+++ b/src/Encamina.Enmarcha.Core/StringToBooleanConverter.cs
@@ -1,0 +1,44 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Encamina.Enmarcha.Core;
+
+/// <summary>
+/// Provides functionality to convert between JSON values and <see langword="bool"/> values during serialization and
+/// deserialization.
+/// </summary>
+/// <remarks>This converter supports deserializing JSON boolean values (<see langword="true"/> or <see
+/// langword="false"/>)  as well as string representations of boolean values ("True" or "False", case-insensitive).  If
+/// an invalid string value is encountered during deserialization, a <see cref="JsonException"/> is thrown. During
+/// serialization, boolean values are written as JSON boolean literals.</remarks>
+public class StringToBooleanConverter : JsonConverter<bool>
+{
+    /// <summary>
+    /// Reads and converts a JSON value to a boolean.
+    /// </summary>
+    /// <inheritdoc/>
+    public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.True => true,
+            JsonTokenType.False => false,
+            JsonTokenType.String => reader.GetString() switch
+            {
+                var value when string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase) => true,
+                var value when string.Equals(value, bool.FalseString, StringComparison.OrdinalIgnoreCase) => false,
+                _ => throw new JsonException($"Invalid string value for boolean: {reader.GetString()}"),
+            },
+            _ => throw new JsonException($"Invalid token type: {reader.TokenType}"),
+        };
+    }
+
+    /// <summary>
+    /// Writes a boolean value to the specified <see cref="Utf8JsonWriter"/>.
+    /// </summary>
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+    {
+        writer.WriteBooleanValue(value);
+    }
+}

--- a/src/Encamina.Enmarcha.Core/StringToBooleanConverter.cs
+++ b/src/Encamina.Enmarcha.Core/StringToBooleanConverter.cs
@@ -23,11 +23,15 @@ public class StringToBooleanConverter : JsonConverter<bool>
         {
             JsonTokenType.True => true,
             JsonTokenType.False => false,
-            JsonTokenType.String => reader.GetString() switch
+            JsonTokenType.String =>
             {
-                var value when string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase) => true,
-                var value when string.Equals(value, bool.FalseString, StringComparison.OrdinalIgnoreCase) => false,
-                _ => throw new JsonException($"Invalid string value for boolean: {reader.GetString()}"),
+                var value = reader.GetString();
+                return value switch
+                {
+                    var v when string.Equals(v, bool.TrueString, StringComparison.OrdinalIgnoreCase) => true,
+                    var v when string.Equals(v, bool.FalseString, StringComparison.OrdinalIgnoreCase) => false,
+                    _ => throw new JsonException($"Invalid string value for boolean: {value}"),
+                };
             },
             _ => throw new JsonException($"Invalid token type: {reader.TokenType}"),
         };

--- a/src/Encamina.Enmarcha.Core/StringToBooleanConverter.cs
+++ b/src/Encamina.Enmarcha.Core/StringToBooleanConverter.cs
@@ -19,18 +19,26 @@ public class StringToBooleanConverter : JsonConverter<bool>
     /// <inheritdoc/>
     public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        return reader.TokenType switch
+        switch (reader.TokenType)
         {
-            JsonTokenType.True => true,
-            JsonTokenType.False => false,
-            JsonTokenType.String => reader.GetString() switch
-            {
-                var value when string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase) => true,
-                var value when string.Equals(value, bool.FalseString, StringComparison.OrdinalIgnoreCase) => false,
-                _ => throw new JsonException($"Invalid string value for boolean: {reader.GetString()}"),
-            },
-            _ => throw new JsonException($"Invalid token type: {reader.TokenType}"),
-        };
+            case JsonTokenType.True:
+                return true;
+
+            case JsonTokenType.False:
+                return false;
+
+            case JsonTokenType.String:
+                {
+                    var value = reader.GetString();
+
+                    return string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase) || (string.Equals(value, bool.FalseString, StringComparison.OrdinalIgnoreCase)
+                        ? false
+                        : throw new JsonException($"Invalid string value for boolean: {value}"));
+                }
+
+            default:
+                throw new JsonException($"Invalid token type: {reader.TokenType}");
+        }
     }
 
     /// <summary>

--- a/src/Encamina.Enmarcha.Core/StringToBooleanConverter.cs
+++ b/src/Encamina.Enmarcha.Core/StringToBooleanConverter.cs
@@ -23,15 +23,11 @@ public class StringToBooleanConverter : JsonConverter<bool>
         {
             JsonTokenType.True => true,
             JsonTokenType.False => false,
-            JsonTokenType.String =>
+            JsonTokenType.String => reader.GetString() switch
             {
-                var value = reader.GetString();
-                return value switch
-                {
-                    var v when string.Equals(v, bool.TrueString, StringComparison.OrdinalIgnoreCase) => true,
-                    var v when string.Equals(v, bool.FalseString, StringComparison.OrdinalIgnoreCase) => false,
-                    _ => throw new JsonException($"Invalid string value for boolean: {value}"),
-                };
+                var value when string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase) => true,
+                var value when string.Equals(value, bool.FalseString, StringComparison.OrdinalIgnoreCase) => false,
+                _ => throw new JsonException($"Invalid string value for boolean: {reader.GetString()}"),
             },
             _ => throw new JsonException($"Invalid token type: {reader.TokenType}"),
         };

--- a/src/Encamina.Enmarcha.Net.Http/MediaTypeNames.cs
+++ b/src/Encamina.Enmarcha.Net.Http/MediaTypeNames.cs
@@ -18,7 +18,7 @@ public static class MediaTypeNames
         /// <summary>
         /// Specifies that the Media Type data is an AdaptiveCard Card (<see href="https://adaptivecards.io/"/>).
         /// </summary>
-        public const string AdaptiveCard = @"application/vnd.microsoft.card.adaptive";
+        public const string AdaptativeCard = @"application/vnd.microsoft.card.adaptive";
 
         /// <summary>
         /// Specifies that the Media Type data is an Excel file (<c>.xlsx</c>).

--- a/src/Encamina.Enmarcha.Net.Http/MediaTypeNames.cs
+++ b/src/Encamina.Enmarcha.Net.Http/MediaTypeNames.cs
@@ -16,9 +16,9 @@ public static class MediaTypeNames
     public static class Application
     {
         /// <summary>
-        /// Specifies that the Media Type data is an Adaptative Card (<see href="https://adaptivecards.io/"/>).
+        /// Specifies that the Media Type data is an AdaptiveCard Card (<see href="https://adaptivecards.io/"/>).
         /// </summary>
-        public const string AdaptativeCard = @"application/vnd.microsoft.card.adaptive";
+        public const string AdaptiveCard = @"application/vnd.microsoft.card.adaptive";
 
         /// <summary>
         /// Specifies that the Media Type data is an Excel file (<c>.xlsx</c>).

--- a/src/Encamina.Enmarcha.Net.Http/MediaTypeNames.cs
+++ b/src/Encamina.Enmarcha.Net.Http/MediaTypeNames.cs
@@ -16,7 +16,7 @@ public static class MediaTypeNames
     public static class Application
     {
         /// <summary>
-        /// Specifies that the Media Type data is an Adaptive Card (<see href="https://adaptivecards.io/"/>).
+        /// Specifies that the Media Type data is an AdaptiveCard Card (<see href="https://adaptivecards.io/"/>).
         /// </summary>
         public const string AdaptiveCard = @"application/vnd.microsoft.card.adaptive";
 

--- a/src/Encamina.Enmarcha.Net.Http/MediaTypeNames.cs
+++ b/src/Encamina.Enmarcha.Net.Http/MediaTypeNames.cs
@@ -18,7 +18,7 @@ public static class MediaTypeNames
         /// <summary>
         /// Specifies that the Media Type data is an AdaptiveCard Card (<see href="https://adaptivecards.io/"/>).
         /// </summary>
-        public const string AdaptativeCard = @"application/vnd.microsoft.card.adaptive";
+        public const string AdaptiveCard = @"application/vnd.microsoft.card.adaptive";
 
         /// <summary>
         /// Specifies that the Media Type data is an Excel file (<c>.xlsx</c>).

--- a/src/Encamina.Enmarcha.Net.Http/MediaTypeNames.cs
+++ b/src/Encamina.Enmarcha.Net.Http/MediaTypeNames.cs
@@ -16,7 +16,7 @@ public static class MediaTypeNames
     public static class Application
     {
         /// <summary>
-        /// Specifies that the Media Type data is an AdaptiveCard Card (<see href="https://adaptivecards.io/"/>).
+        /// Specifies that the Media Type data is an Adaptive Card (<see href="https://adaptivecards.io/"/>).
         /// </summary>
         public const string AdaptiveCard = @"application/vnd.microsoft.card.adaptive";
 


### PR DESCRIPTION
# Description

- Added NuGet packages for adaptive cards, Azure Tables, HTTP utilities, and Swagger annotations.
- Introduced `LiveActivityManager` for managing live activities, including history tracking and adaptive card updates.
- Added `CommonConstants` for centralized logging and header constants.
- Implemented `AgentCustomEventsFilter` and `LogAIRequestScopeMiddleware` for improved telemetry and structured logging.
- Created models (`AgentRequest`, `LiveActivityStatus`, `LiveActivityUpdateRequest`) for standardized live activity handling.
- Added `LiveActivityManagerOptions` for configurable history limits and adaptive card templates.
- Introduced telemetry initializers for assembly name and AI request correlation.
- Added `HttpContextExtensions` for simplified HTTP header handling.
- Implemented `StringToBooleanConverter` for flexible JSON boolean handling.

## Motivation and Context

We are looking to migrate from our Project. The Avolta AI services solution currently contains several infrastructure and cross-cutting components (logging middleware, telemetry initializers, live activity manager, JSON converters, etc.) that are not Avolta-specific and are already useful (or clearly reusable) across other projects.

## Type of change

Please check only those options that are relevant with a (✅).

- [✅] The code builds clean without any errors or warnings
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

Please check all options from this checklist when validating your pull request with a (✅).

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [✅] Any dependent changes have been merged and published in downstream modules
- [✅] I didn't break anyone :smile:
