### PR TITLE
Update version suffix to preview-08

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>10.0.0</VersionPrefix>
-    <VersionSuffix>preview-07</VersionSuffix>
+    <VersionSuffix>preview-08</VersionSuffix>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Bumped the VersionSuffix property from preview-07 to preview-08 in Directory.Build.props.

# Description

Updating version in  Directory.Build.props

## Motivation and Context

This way we can create a new version of ENMARCHA.

## Type of change

Please check only those options that are relevant with a (✅).

- [✅] The code builds clean without any errors or warnings
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

Please check all options from this checklist when validating your pull request with a (✅).

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [✅] Any dependent changes have been merged and published in downstream modules
- [✅] I didn't break anyone :smile:
