### PR TITLE
Add SemanticKernel rate limit middleware

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <VersionPrefix>10.0.0</VersionPrefix>
-    <VersionSuffix>preview-08</VersionSuffix>
+    <VersionSuffix>preview-09</VersionSuffix>
   </PropertyGroup>
 
   <!--

--- a/src/Encamina.Enmarcha.Agents/Encamina.Enmarcha.Agents.csproj
+++ b/src/Encamina.Enmarcha.Agents/Encamina.Enmarcha.Agents.csproj
@@ -17,6 +17,7 @@
       <PackageReference Include="Microsoft.Agents.Storage.CosmosDb" Version="1.2.41" />
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
+      <PackageReference Include="Microsoft.SemanticKernel" Version="1.64.0" />
       <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.0.0" />
     </ItemGroup>
 

--- a/src/Encamina.Enmarcha.Agents/Middlewares/LogAIRequestScopeMiddleware.cs
+++ b/src/Encamina.Enmarcha.Agents/Middlewares/LogAIRequestScopeMiddleware.cs
@@ -10,7 +10,7 @@ namespace Encamina.Enmarcha.Agents.Middlewares;
 /// It extracts specific headers from the request (e.g., ActivityId, UserId)
 /// and includes them in the log scope for better traceability.
 /// </summary>
-internal sealed class LogAIRequestScopeMiddleware
+public class LogAIRequestScopeMiddleware
 {
     private readonly RequestDelegate next;
     private readonly ILogger<LogAIRequestScopeMiddleware> logger;

--- a/src/Encamina.Enmarcha.Agents/Middlewares/SemanticKernelRateLimitMiddleware.cs
+++ b/src/Encamina.Enmarcha.Agents/Middlewares/SemanticKernelRateLimitMiddleware.cs
@@ -1,0 +1,105 @@
+﻿using System.Runtime.ExceptionServices;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+
+namespace Encamina.Enmarcha.Agents.Middlewares;
+
+/// <summary>
+/// A middleware that catches rate limit (429) exceptions from the Semantic Kernel and returns a 429 Too Many Requests response.
+/// </summary>
+public class SemanticKernelRateLimitMiddleware
+{
+    private const string DefaultErrorMessage = @"The request was rate limited. Please try again later.";
+
+    private readonly ILogger<SemanticKernelRateLimitMiddleware> logger;
+    private readonly RequestDelegate next;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemanticKernelRateLimitMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The delegate representing the remaining middleware in the request pipeline.</param>
+    /// <param name="logger">The logger for the middleware.</param>
+    public SemanticKernelRateLimitMiddleware(RequestDelegate next, ILogger<SemanticKernelRateLimitMiddleware> logger)
+    {
+        this.logger = logger;
+        this.next = next;
+    }
+
+    /// <summary>
+    /// Executes the middleware.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
+    /// <returns>A task that represents the execution of this middleware.</returns>
+    public Task InvokeAsync(HttpContext context)
+    {
+        ExceptionDispatchInfo? exceptionDispatchInfo;
+
+        try
+        {
+            var task = next(context);
+
+            return !task.IsCompletedSuccessfully
+                ? Awaited(this, context, task)
+                : Task.CompletedTask;
+        }
+        catch (HttpOperationException httpOperationException)
+        {
+            // Get the Exception, but don't continue processing in the catch block as its bad for stack usage.
+            exceptionDispatchInfo = ExceptionDispatchInfo.Capture(httpOperationException);
+        }
+
+        return HandleExceptionAsync(context, exceptionDispatchInfo);
+
+        static async Task Awaited(SemanticKernelRateLimitMiddleware middleware, HttpContext context, Task task)
+        {
+            ExceptionDispatchInfo? exceptionDispatchInfo = null;
+
+            try
+            {
+                await task;
+            }
+            catch (HttpOperationException exception)
+            {
+                // Get the Exception, but don't continue processing in the catch block as its bad for stack usage.
+                exceptionDispatchInfo = ExceptionDispatchInfo.Capture(exception);
+            }
+
+            if (exceptionDispatchInfo != null)
+            {
+                await middleware.HandleExceptionAsync(context, exceptionDispatchInfo);
+            }
+        }
+    }
+
+    private async Task HandleExceptionAsync(HttpContext context, ExceptionDispatchInfo exceptionDispatchInfo)
+    {
+        var exception = (HttpOperationException)exceptionDispatchInfo.SourceException;
+
+        // Check if it's a 429 error based on the HttpOperationException status code
+        if (exception.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+        {
+            logger.LogWarning(exception, "Rate limit exceeded (429) for request to {Path}", context.Request.Path);
+
+            context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+            context.Response.ContentType = @"application/json";
+
+            string? retryAfter = null;
+            if (exception.InnerException is System.ClientModel.ClientResultException azureEx)
+            {
+                var rawResponse = azureEx.GetRawResponse();
+                if (rawResponse?.Headers.TryGetValue("Retry-After", out retryAfter) == true)
+                {
+                    context.Response.Headers.Append("Retry-After", retryAfter);
+                }
+            }
+
+            await context.Response.WriteAsync(DefaultErrorMessage).ConfigureAwait(false);
+            return; // Stop further processing as we have handled the exception.
+        }
+
+        // If the internal exception is not a 429, rethrow the original exception.
+        exceptionDispatchInfo.Throw();
+    }
+}

--- a/src/Encamina.Enmarcha.Agents/Middlewares/SemanticKernelRateLimitMiddleware.cs
+++ b/src/Encamina.Enmarcha.Agents/Middlewares/SemanticKernelRateLimitMiddleware.cs
@@ -101,7 +101,7 @@ public class SemanticKernelRateLimitMiddleware
                 error = DefaultErrorMessage,
             });
 
-            await context.Response.WriteAsync(payload).ConfigureAwait(false);
+            await context.Response.WriteAsync(payload);
             return;
         }
 

--- a/src/Encamina.Enmarcha.Agents/Middlewares/SemanticKernelRateLimitMiddleware.cs
+++ b/src/Encamina.Enmarcha.Agents/Middlewares/SemanticKernelRateLimitMiddleware.cs
@@ -13,8 +13,8 @@ public class SemanticKernelRateLimitMiddleware
 {
     private const string DefaultErrorMessage = @"The request was rate limited. Please try again later.";
 
-    private readonly ILogger<SemanticKernelRateLimitMiddleware> logger;
     private readonly RequestDelegate next;
+    private readonly ILogger<SemanticKernelRateLimitMiddleware> logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SemanticKernelRateLimitMiddleware"/> class.

--- a/src/Encamina.Enmarcha.Agents/Middlewares/SemanticKernelRateLimitMiddleware.cs
+++ b/src/Encamina.Enmarcha.Agents/Middlewares/SemanticKernelRateLimitMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.ExceptionServices;
+using System.Text.Json;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -95,8 +96,13 @@ public class SemanticKernelRateLimitMiddleware
                 }
             }
 
-            await context.Response.WriteAsync(DefaultErrorMessage).ConfigureAwait(false);
-            return; // Stop further processing as we have handled the exception.
+            var payload = JsonSerializer.Serialize(new
+            {
+                error = DefaultErrorMessage,
+            });
+
+            await context.Response.WriteAsync(payload).ConfigureAwait(false);
+            return;
         }
 
         // If the internal exception is not a 429, rethrow the original exception.


### PR DESCRIPTION
# Description

Introduces SemanticKernelRateLimitMiddleware . Also updates LogAIRequestScopeMiddleware to public and adds Microsoft.SemanticKernel package reference. Version suffix updated to preview-09.

## Motivation and Context

Migrating a new middleware to handle 429 rate limit exceptions from Semantic Kernel and return appropriate HTTP responses, and necessary packages.

## Type of change

Please check only those options that are relevant with a (✅).

- [✅] The code builds clean without any errors or warnings
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

Please check all options from this checklist when validating your pull request with a (✅).

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [✅] Any dependent changes have been merged and published in downstream modules
- [✅] I didn't break anyone :smile:
