### PR TITLE
Update Swashbuckle packages to 8.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Also, any bug fix must start with the prefix �Bug fix:� followed by the desc
 
 Previous classification is not required if changes are simple or all belong to the same category.
 
+## [10.0.2]
+
+### Major Changes
+- Consolidate `Swashbuckle.AspNetCore.X` packages to version `8.1.4`. Semantic Kernel version `1.68.0` requires `Microsoft.OpenApi` version `1.6.x` which is not compatible with `Swashbuckle.AspNetCore` versions later than `8.x.x`.
+
 ## [10.0.1]
 
 ### Minor Changes

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>10.0.1</VersionPrefix>
+    <VersionPrefix>10.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/Encamina.Enmarcha.Agents/Encamina.Enmarcha.Agents.csproj
+++ b/src/Encamina.Enmarcha.Agents/Encamina.Enmarcha.Agents.csproj
@@ -18,7 +18,8 @@
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
       <PackageReference Include="Microsoft.SemanticKernel" Version="1.68.0" />
-      <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.0.1" />
+      <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.4" />
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Encamina.Enmarcha.AspNet.OpenApi.Swashbuckle/Encamina.Enmarcha.AspNet.OpenApi.Swashbuckle.csproj
+++ b/src/Encamina.Enmarcha.AspNet.OpenApi.Swashbuckle/Encamina.Enmarcha.AspNet.OpenApi.Swashbuckle.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>      
       <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.7.3" />
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Encamina.Enmarcha.AspNet.OpenApi.Swashbuckle/OperationFilters/ApiKeyHeaderOperationFilter.cs
+++ b/src/Encamina.Enmarcha.AspNet.OpenApi.Swashbuckle/OperationFilters/ApiKeyHeaderOperationFilter.cs
@@ -44,10 +44,7 @@ public sealed class ApiKeyHeaderOperationFilter : IOperationFilter
     /// <inheritdoc/>
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
-        if (operation.Parameters == null)
-        {
-            operation.Parameters = new List<OpenApiParameter>();
-        }
+        operation.Parameters ??= [];
 
         operation.Parameters.Add(new OpenApiParameter()
         {


### PR DESCRIPTION
# Description

Consolidates Swashbuckle.AspNetCore.X dependencies to version 8.1.4 for compatibility with Semantic Kernel 1.68.0.

Semantic Kernel version `1.68.0` requires `Microsoft.OpenApi` version `1.6.x` which is not compatible with `Swashbuckle.AspNetCore` versions later than `8.x.x`.

Updates version to 10.0.2 and refactors ApiKeyHeaderOperationFilter to use collection expression for parameter initialization.

## Type of change

Please check only those options that are relevant with a (✅).

- [✅] The code builds clean without any errors or warnings
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

Please check all options from this checklist when validating your pull request with a (✅).

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [✅] Any dependent changes have been merged and published in downstream modules
- [✅] I didn't break anyone :smile:
