### PR TITLE
Fix mistral http request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Also, any bug fix must start with the prefix �Bug fix:� followed by the desc
 
 Previous classification is not required if changes are simple or all belong to the same category.
 
+## [10.0.4]
+
+### Minor Changes
+
+- Replaced `JsonContent.Create()` with `StringContent` to ensure explicit `Content-Length` header required by Mistral AI API (rejects chunked transfer encoding).
+
 ## [10.0.3]
 
 ### Minor Changes

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>10.0.3</VersionPrefix>
+    <VersionPrefix>10.0.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/MistralAIDocumentConnector.cs
+++ b/src/Encamina.Enmarcha.SemanticKernel.Connectors.Document/Connectors/MistralAIDocumentConnector.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http.Json;
 using System.Text;
+using System.Text.Json;
 
 using CommunityToolkit.Diagnostics;
 
@@ -267,20 +268,26 @@ public class MistralAIDocumentConnector : IEnmarchaDocumentConnector
     {
         var documentUrl = await MistralAIHelper.BuildPdfDataUrlAsync(pdfPart, cancellationToken);
 
+        var requestBody = new
+        {
+            model = mistralAIDocumentConnectorOptions.ModelName,
+            document = new
+            {
+                type = "document_url",
+                document_url = documentUrl,
+            },
+            include_image_base64 = true,
+        };
+
+        var jsonString = JsonSerializer.Serialize(requestBody);
+
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, mistralAIDocumentConnectorOptions.Endpoint)
         {
             Headers = { { "Authorization", $"Bearer {mistralAIDocumentConnectorOptions.ApiKey}" } },
-            Content = JsonContent.Create(new
-            {
-                model = mistralAIDocumentConnectorOptions.ModelName,
-                document = new
-                {
-                    type = "document_url",
-                    document_url = documentUrl,
-                },
-                include_image_base64 = true,
-            }),
+            Content = new StringContent(jsonString, Encoding.UTF8, "application/json"),
         };
+
+        httpRequest.Content.Headers.ContentLength = Encoding.UTF8.GetByteCount(jsonString);
 
         using var httpResponse = await httpClient.SendAsync(httpRequest, cancellationToken);
 


### PR DESCRIPTION
# Description

Replaced `JsonContent.Create()` with `StringContent` to ensure explicit `Content-Length` header required by Mistral AI API (rejects chunked transfer encoding).

## Motivation and Context

Mistral AI API rejects HTTP requests using chunked transfer encoding, requiring an explicit `Content-Length` header instead. The previous implementation using `JsonContent.Create()` automatically applied chunked encoding, resulting in HTTP 400 errors with `x-ms-error-code: no_content_length_header`.

This change ensures PDF document processing succeeds by:
1. Serializing the request payload to a JSON string first
2. Using `StringContent` with explicit `Content-Length` calculation
3. Preventing automatic chunked transfer encoding

Fixes document extraction failures when processing PDFs through `MistralAIDocumentConnector`.

## Type of change

Please check only those options that are relevant with a (✅).

- [✅] The code builds clean without any errors or warnings
- [✅] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

Please check all options from this checklist when validating your pull request with a (✅).

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [✅] Any dependent changes have been merged and published in downstream modules
- [✅] I didn't break anyone :smile:
